### PR TITLE
Fix CI: Restore missing runs-on key in workflow

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -8,6 +8,7 @@ on:
 
 jobs:
   test:
+    runs-on: ubuntu-latest
     permissions:
       contents: read
     steps:


### PR DESCRIPTION
## 🐛 Bug Fix
Restores the missing `runs-on: ubuntu-latest` key in [.github/workflows/tests.yml](cci:7://file:///C:/Users/rahul/.gemini/antigravity/playground/vector-meteoroid/qwed-finance/.github/workflows/tests.yml:0:0-0:0).

## 📝 Context
The previous merge unintentionally removed this key while updating permissions, causing "Invalid workflow file" errors. This hotfix restores valid syntax to get CI running again.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated internal CI/CD workflow configuration.

---

**Note:** This release contains no user-facing changes or new features.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->