### PR TITLE
fix: Set verification_mode=HEURISTIC when Newton-Raphson fallback is used

### DIFF
--- a/tests/test_finance_verifier.py
+++ b/tests/test_finance_verifier.py
@@ -146,6 +146,30 @@ class TestIRRVerification:
         )
         # IRR should be around 14.49%
         assert result.computed_value is not None
+    
+    def test_irr_verification_mode_symbolic(self):
+        """Test IRR returns SYMBOLIC when SymPy works"""
+        result = self.verifier.verify_irr(
+            cashflows=[-1000, 500, 600],
+            llm_output="10%"
+        )
+        # Simple cashflows should use symbolic solver
+        assert result.verification_mode in ["SYMBOLIC", "HEURISTIC"]
+    
+    def test_irr_newton_raphson_fallback(self):
+        """Test IRR fallback when SymPy unavailable (mock scenario)"""
+        verifier = FinanceVerifier()
+        # Force SymPy unavailable to trigger fallback
+        verifier._sympy_available = False
+        
+        result = verifier.verify_irr(
+            cashflows=[-1000, 300, 400, 400, 300],
+            llm_output="14.49%"
+        )
+        
+        # Should use Newton-Raphson and report HEURISTIC
+        assert result.verification_mode == "HEURISTIC"
+        assert result.computed_value is not None
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
Fixes CodeRabbit issue where `verification_mode` was always returning "SYMBOLIC" even when Newton-Raphson numeric fallback was used.

## Changes
- Added `used_fallback` flag to track when SymPy fails and Newton-Raphson is used
- [verify_irr](cci:1://file:///C:/Users/rahul/.gemini/antigravity/playground/vector-meteoroid/qwed-finance/qwed_finance/finance_verifier.py:108:4-177:9) now correctly returns:
  - `verification_mode="SYMBOLIC"` when SymPy finds real roots
  - `verification_mode="HEURISTIC"` when Newton-Raphson fallback is triggered

## Why This Matters
Users relying on `verification_mode` to determine if a result is 100% deterministic were getting misleading data. Newton-Raphson is an approximation method (heuristic), not a symbolic proof.

## Testing
- Existing tests pass
- Manual verification: IRR with complex cashflows now correctly reports HEURISTIC mode

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * IRR verification now correctly marks results as HEURISTIC when a fallback numeric method is used, improving transparency about how values were computed.
* **Tests**
  * Added tests to ensure verification mode is reported correctly for both symbolic and fallback computation paths, and that fallback produces a valid IRR value.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->