### PR TITLE
fix: pin codeql-action/upload-sarif to commit SHA (v4.32.5)

### DIFF
--- a/.github/workflows/dogfood.yml
+++ b/.github/workflows/dogfood.yml
@@ -143,7 +143,7 @@ jobs:
       
       - name: Upload SARIF
         if: always()
-        uses: github/codeql-action/upload-sarif@v4
+        uses: github/codeql-action/upload-sarif@c793b717bc78562f491db7b0e93a3a178b099162 # v4.32.5
         with:
           sarif_file: qwed-finance-results.sarif
 


### PR DESCRIPTION
Pin `github/codeql-action/upload-sarif` from mutable `@v4` tag to immutable commit SHA `@c793b717bc78562f491db7b0e93a3a178b099162` in [dogfood.yml](cci:7://file:///C:/Users/rahul/.gemini/antigravity/playground/vector-meteoroid/qwed-finance/.github/workflows/dogfood.yml:0:0-0:0). Follows GitHub security hardening best practice for reproducible workflows.
