### PR TITLE
fix: export ISOGuard, add jsonschema dep, README fixes (Ten Guards)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,11 +8,10 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     git \
     && rm -rf /var/lib/apt/lists/*
 
-# Install Python dependencies
-RUN pip install --no-cache-dir pandas sympy sqlglot z3-solver jsonschema
-
-# Copy the entire qwed_finance package (local)
+# Install Python dependencies from project metadata (single source of truth)
+COPY pyproject.toml /app/pyproject.toml
 COPY qwed_finance/ /app/qwed_finance/
+RUN pip install --no-cache-dir /app pandas
 
 # Copy action entrypoint
 COPY action_entrypoint.py /app/action_entrypoint.py

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     && rm -rf /var/lib/apt/lists/*
 
 # Install Python dependencies
-RUN pip install --no-cache-dir pandas sympy
+RUN pip install --no-cache-dir pandas sympy sqlglot z3-solver jsonschema
 
 # Copy the entire qwed_finance package (local)
 COPY qwed_finance/ /app/qwed_finance/

--- a/README.md
+++ b/README.md
@@ -629,7 +629,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       
-      - uses: QWED-AI/qwed-finance@v2
+      - uses: QWED-AI/qwed-finance@v2.0.1
         with:
           test-script: tests/verify_agent.py
 ```

--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ QWED-Finance is a **middleware layer** that applies QWED's deterministic verific
 
 ---
 
-## 🛡️ The Six Guards
+## 🛡️ The Ten Guards
 
 ### 1. Compliance Guard (Z3-Powered)
 **KYC/AML regulatory verification with formal boolean logic proofs.**
@@ -358,6 +358,24 @@ result = guard.verify_max_drawdown(
 - Expected Shortfall (CVaR)
 - Information Ratio
 
+### 10. ISO Guard (Banking Schema Validation)
+**Validate AI-generated payment messages against ISO 20022 JSON schemas.**
+
+```python
+from qwed_finance import ISOGuard
+
+guard = ISOGuard()
+
+# Verify ISO 20022 pacs.008 payment message
+result = guard.verify_payment_message({
+    "MsgId": "MSG001",
+    "CreDtTm": "2026-01-15T10:30:00Z",
+    "NbOfTxs": 1,
+    "TtlIntrBkSttlmAmt": {"amount": 50000.00, "currency": "USD"}
+})
+# result = {"verified": True, "standard": "ISO 20022"}
+```
+
 ---
 
 
@@ -585,8 +603,11 @@ Typically <5ms for simple calculations, <50ms for complex derivatives pricing. T
 | Package | Description |
 |---------|-------------|
 | [qwed-verification](https://github.com/QWED-AI/qwed-verification) | Core verification engine |
+| [qwed-legal](https://github.com/QWED-AI/qwed-legal) | Legal contract verification |
+| [qwed-tax](https://github.com/QWED-AI/qwed-tax) | Tax calculation verification |
 | [qwed-ucp](https://github.com/QWED-AI/qwed-ucp) | E-commerce verification |
 | [qwed-mcp](https://github.com/QWED-AI/qwed-mcp) | Claude Desktop integration |
+
 ---
 
 ## 🤖 GitHub Action for CI/CD
@@ -608,7 +629,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       
-      - uses: QWED-AI/qwed-finance@v1.1.1
+      - uses: QWED-AI/qwed-finance@v2
         with:
           test-script: tests/verify_agent.py
 ```

--- a/README.md
+++ b/README.md
@@ -373,7 +373,8 @@ result = guard.verify_payment_message({
     "NbOfTxs": 1,
     "TtlIntrBkSttlmAmt": {"amount": 50000.00, "currency": "USD"}
 })
-# result = {"verified": True, "standard": "ISO 20022"}
+# result.verified = True  ✅
+# result.standard = "ISO 20022"
 ```
 
 ---

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,7 +25,7 @@ keywords = [
     "amortization"
 ]
 classifiers = [
-    "Development Status :: 3 - Alpha",
+    "Development Status :: 4 - Beta",
     "Intended Audience :: Developers",
     "Intended Audience :: Financial and Insurance Industry",
     "License :: OSI Approved :: Apache Software License",
@@ -40,6 +40,7 @@ dependencies = [
     "sympy>=1.12",
     "sqlglot>=20.0.0",
     "z3-solver>=4.12.0",
+    "jsonschema>=4.0.0",
 ]
 
 [project.optional-dependencies]

--- a/qwed_finance/__init__.py
+++ b/qwed_finance/__init__.py
@@ -29,7 +29,7 @@ from .cross_guard import CrossGuard, CrossGuardResult
 from .bond_guard import BondGuard, BondResult
 from .fx_guard import FXGuard, FXResult, QuoteConvention
 from .risk_guard import RiskGuard, RiskResult, VaRMethod, ConfidenceLevel
-from .guards.iso_guard import ISOGuard
+from .guards.iso_guard import ISOGuard, ISOResult
 from .models.receipt import (
     VerificationReceipt, 
     VerificationEngine, 
@@ -102,6 +102,7 @@ __all__ = [
 
     # ISO Guard
     "ISOGuard",
+    "ISOResult",
     
     # Audit Trail
     "VerificationReceipt",

--- a/qwed_finance/__init__.py
+++ b/qwed_finance/__init__.py
@@ -1,18 +1,19 @@
 """
 QWED-Finance: Deterministic verification for banking and financial AI
 
-v2.0.0 - Major Release
+v2.0.1
 
-Nine Guards + Audit Trail + Integrations:
+Ten Guards + Audit Trail + Integrations:
 - ComplianceGuard: KYC/AML regulatory logic (Z3)
 - CalendarGuard: Day count conventions (SymPy)
 - DerivativesGuard: Options pricing & margin (Black-Scholes)
 - MessageGuard: ISO 20022 / SWIFT validation (XML Schema)
 - QueryGuard: SQL safety & table access (SQLGlot AST)
 - CrossGuard: Multi-layer verification integration
-- BondGuard: YTM, Duration, Convexity verification [NEW in v2.0]
-- FXGuard: Forward rates, Cross rates, NDF settlement [NEW in v2.0]
-- RiskGuard: VaR, Beta, Sharpe, Sortino, Max Drawdown [NEW in v2.0]
+- BondGuard: YTM, Duration, Convexity verification
+- FXGuard: Forward rates, Cross rates, NDF settlement
+- RiskGuard: VaR, Beta, Sharpe, Sortino, Max Drawdown
+- ISOGuard: ISO 20022 JSON schema validation
 - VerificationReceipt: Cryptographic audit trail
 - OpenResponsesIntegration: Agentic tool call verification
 - UCPIntegration: Payment token verification
@@ -28,6 +29,7 @@ from .cross_guard import CrossGuard, CrossGuardResult
 from .bond_guard import BondGuard, BondResult
 from .fx_guard import FXGuard, FXResult, QuoteConvention
 from .risk_guard import RiskGuard, RiskResult, VaRMethod, ConfidenceLevel
+from .guards.iso_guard import ISOGuard
 from .models.receipt import (
     VerificationReceipt, 
     VerificationEngine, 
@@ -97,6 +99,9 @@ __all__ = [
     "RiskResult",
     "VaRMethod",
     "ConfidenceLevel",
+
+    # ISO Guard
+    "ISOGuard",
     
     # Audit Trail
     "VerificationReceipt",

--- a/qwed_finance/guards/iso_guard.py
+++ b/qwed_finance/guards/iso_guard.py
@@ -1,6 +1,19 @@
 import json
 import jsonschema
-from typing import Dict, Any
+from typing import Dict, Any, List, Optional
+from dataclasses import dataclass, field
+
+
+@dataclass
+class ISOResult:
+    """Result of ISO 20022 schema validation."""
+    verified: bool
+    standard: str = "ISO 20022"
+    msg_type: str = ""
+    error: str = ""
+    path: List[str] = field(default_factory=list)
+    verification_mode: str = "SCHEMA"
+
 
 class ISOGuard:
     """
@@ -28,19 +41,25 @@ class ISOGuard:
             "required": ["MsgId", "CreDtTm", "NbOfTxs"]
         }
 
-    def verify_payment_message(self, message: Dict[str, Any], msg_type: str = "pacs.008") -> Dict[str, Any]:
+    def verify_payment_message(self, message: Dict[str, Any], msg_type: str = "pacs.008") -> ISOResult:
         """
         Validates AI-generated payment instructions against ISO 20022 standards.
         """
         if msg_type != "pacs.008":
-            return {"verified": False, "error": "Unsupported message type"}
+            return ISOResult(
+                verified=False,
+                msg_type=msg_type,
+                error=f"Unsupported message type: {msg_type}"
+            )
 
         try:
             jsonschema.validate(instance=message, schema=self.pacs_008_schema)
-            return {"verified": True, "standard": "ISO 20022"}
+            return ISOResult(verified=True, msg_type=msg_type)
         except jsonschema.ValidationError as e:
-            return {
-                "verified": False, 
-                "error": f"Schema Violation: {e.message}",
-                "path": list(e.path)
-            }
+            return ISOResult(
+                verified=False,
+                msg_type=msg_type,
+                error=f"Schema Violation: {e.message}",
+                path=[str(p) for p in e.path]
+            )
+

--- a/qwed_finance/guards/iso_guard.py
+++ b/qwed_finance/guards/iso_guard.py
@@ -1,6 +1,6 @@
 import json
 import jsonschema
-from typing import Dict, Any, List, Optional
+from typing import Dict, Any, List
 from dataclasses import dataclass, field
 
 


### PR DESCRIPTION
## Summary
Exports the hidden ISOGuard, fixes README guard count, and aligns with ecosystem standards.

## Changes
- **Export `ISOGuard`** from `guards/iso_guard.py` (was dead code)
- **Add `jsonschema>=4.0.0`** dependency (required by ISOGuard)
- **README:** "Six Guards" → "Ten Guards", added ISOGuard section (#10)
- **README:** Action version `v1.1.1` → `v2`
- **README:** Added `qwed-legal` + `qwed-tax` to related packages
- **pyproject:** `Development Status :: 3 - Alpha` → `4 - Beta`

## Tests
All existing tests pass ✅


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added ISO Guard for banking (ISO 20022) validation and a new ISO result type in the public API
  * Added two new public packages: qwed-legal and qwed-tax

* **Documentation**
  * Updated docs with ISO Guard usage examples and CI snippet pointing to v2.0.1

* **Chores**
  * Project status moved to Beta; version bumped to 2.0.1; added jsonschema and other runtime deps
<!-- end of auto-generated comment: release notes by coderabbit.ai -->