### PR TITLE
chore(security): harden CI/CD pipelines with SHA-pinned GitHub Actions

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -69,7 +69,7 @@ jobs:
 
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL
-      uses: github/codeql-action/init@cb06a0a8527b2c6970741b3a0baa15231dc74a4c # v4.34.1
+      uses: github/codeql-action/init@38697555549f1db7851b81482ff19f1fa5c4fedc # v4.34.1
       with:
         languages: ${{ matrix.language }}
         build-mode: ${{ matrix.build-mode }}
@@ -98,6 +98,6 @@ jobs:
         exit 1
 
     - name: Perform CodeQL Analysis
-      uses: github/codeql-action/analyze@cb06a0a8527b2c6970741b3a0baa15231dc74a4c # v4.34.1
+      uses: github/codeql-action/analyze@38697555549f1db7851b81482ff19f1fa5c4fedc # v4.34.1
       with:
         category: "/language:${{matrix.language}}"

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -59,7 +59,7 @@ jobs:
         # your codebase is analyzed, see https://docs.github.com/en/code-security/code-scanning/creating-an-advanced-setup-for-code-scanning/codeql-code-scanning-for-compiled-languages
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v4
+      uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
 
     # Add any setup steps before running the `github/codeql-action/init` action.
     # This includes steps like installing compilers or runtimes (`actions/setup-node`
@@ -69,7 +69,7 @@ jobs:
 
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL
-      uses: github/codeql-action/init@v4
+      uses: github/codeql-action/init@cb06a0a8527b2c6970741b3a0baa15231dc74a4c # v4.34.1
       with:
         languages: ${{ matrix.language }}
         build-mode: ${{ matrix.build-mode }}
@@ -98,6 +98,6 @@ jobs:
         exit 1
 
     - name: Perform CodeQL Analysis
-      uses: github/codeql-action/analyze@v4
+      uses: github/codeql-action/analyze@cb06a0a8527b2c6970741b3a0baa15231dc74a4c # v4.34.1
       with:
         category: "/language:${{matrix.language}}"

--- a/.github/workflows/dogfood.yml
+++ b/.github/workflows/dogfood.yml
@@ -18,7 +18,7 @@ jobs:
     
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
       
       # Test 1: NPV Verification
       - name: Test NPV Verification
@@ -72,7 +72,7 @@ jobs:
     
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
       
       # Create test data file
       - name: Create NPV Test Data
@@ -121,7 +121,7 @@ jobs:
     
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
       
       - name: Create Test Data with Error
         run: |

--- a/.github/workflows/dogfood.yml
+++ b/.github/workflows/dogfood.yml
@@ -143,7 +143,7 @@ jobs:
       
       - name: Upload SARIF
         if: always()
-        uses: github/codeql-action/upload-sarif@c793b717bc78562f491db7b0e93a3a178b099162 # v4.32.5
+        uses: github/codeql-action/upload-sarif@cb06a0a8527b2c6970741b3a0baa15231dc74a4c # v4.34.1
         with:
           sarif_file: qwed-finance-results.sarif
 

--- a/.github/workflows/dogfood.yml
+++ b/.github/workflows/dogfood.yml
@@ -143,7 +143,7 @@ jobs:
       
       - name: Upload SARIF
         if: always()
-        uses: github/codeql-action/upload-sarif@cb06a0a8527b2c6970741b3a0baa15231dc74a4c # v4.34.1
+        uses: github/codeql-action/upload-sarif@38697555549f1db7851b81482ff19f1fa5c4fedc # v4.34.1
         with:
           sarif_file: qwed-finance-results.sarif
 

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -29,7 +29,7 @@ jobs:
       run: python -m build
     
     - name: Store the distribution packages
-      uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+      uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
       with:
         name: python-package-distributions
         path: dist/
@@ -49,7 +49,7 @@ jobs:
 
     steps:
     - name: Download distributions
-      uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
+      uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
       with:
         name: python-package-distributions
         path: dist/

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -13,10 +13,10 @@ jobs:
       contents: read
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
     
     - name: Set up Python
-      uses: actions/setup-python@v5
+      uses: actions/setup-python@39cd14951b08e74b54015e9e001cdefcf80e669f # v5.1.1
       with:
         python-version: "3.11"
     
@@ -29,7 +29,7 @@ jobs:
       run: python -m build
     
     - name: Store the distribution packages
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
       with:
         name: python-package-distributions
         path: dist/
@@ -49,7 +49,7 @@ jobs:
 
     steps:
     - name: Download distributions
-      uses: actions/download-artifact@v4
+      uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
       with:
         name: python-package-distributions
         path: dist/

--- a/.github/workflows/qwed-verify.yml
+++ b/.github/workflows/qwed-verify.yml
@@ -9,8 +9,8 @@ jobs:
   verify:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
       
-      - uses: QWED-AI/qwed-finance@v1.1.4
+      - uses: QWED-AI/qwed-finance@8002d00bbea4fbd05d486e9d5860a0ea2ca81bfd # v1.1.4
         with:
           test-script: tests/verify_agent.py

--- a/.github/workflows/snyk.yml
+++ b/.github/workflows/snyk.yml
@@ -17,15 +17,15 @@ jobs:
       contents: read
       security-events: write
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@39cd14951b08e74b54015e9e001cdefcf80e669f # v5.1.1
         with:
           python-version: '3.11'
 
       - name: Install Snyk CLI
-        run: npm install -g snyk@1.1303.1
+        run: npm install -g snyk@1.1303.2
 
       - name: Install Python dependencies
         run: |
@@ -44,7 +44,7 @@ jobs:
         run: snyk test --file=requirements.txt --org=${{ secrets.SNYK_ORG_ID }} --severity-threshold=high --sarif-file-output=snyk-python.sarif
 
       - name: Upload Snyk Python results to GitHub Security
-        uses: github/codeql-action/upload-sarif@v4
+        uses: github/codeql-action/upload-sarif@cb06a0a8527b2c6970741b3a0baa15231dc74a4c # v4.34.1
         if: always() && hashFiles('snyk-python.sarif') != ''
         with:
           sarif_file: snyk-python.sarif
@@ -57,10 +57,10 @@ jobs:
       contents: read
       security-events: write
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
 
       - name: Install Snyk CLI
-        run: npm install -g snyk@1.1303.1
+        run: npm install -g snyk@1.1303.2
 
       - name: Snyk Code analysis
         env:
@@ -68,7 +68,7 @@ jobs:
         run: snyk code test --org=${{ secrets.SNYK_ORG_ID }} --severity-threshold=high --sarif-file-output=snyk-code.sarif
 
       - name: Upload Snyk Code results
-        uses: github/codeql-action/upload-sarif@v4
+        uses: github/codeql-action/upload-sarif@cb06a0a8527b2c6970741b3a0baa15231dc74a4c # v4.34.1
         if: always() && hashFiles('snyk-code.sarif') != ''
         with:
           sarif_file: snyk-code.sarif

--- a/.github/workflows/snyk.yml
+++ b/.github/workflows/snyk.yml
@@ -44,7 +44,7 @@ jobs:
         run: snyk test --file=requirements.txt --org=${{ secrets.SNYK_ORG_ID }} --severity-threshold=high --sarif-file-output=snyk-python.sarif
 
       - name: Upload Snyk Python results to GitHub Security
-        uses: github/codeql-action/upload-sarif@cb06a0a8527b2c6970741b3a0baa15231dc74a4c # v4.34.1
+        uses: github/codeql-action/upload-sarif@38697555549f1db7851b81482ff19f1fa5c4fedc # v4.34.1
         if: always() && hashFiles('snyk-python.sarif') != ''
         with:
           sarif_file: snyk-python.sarif
@@ -68,7 +68,7 @@ jobs:
         run: snyk code test --org=${{ secrets.SNYK_ORG_ID }} --severity-threshold=high --sarif-file-output=snyk-code.sarif
 
       - name: Upload Snyk Code results
-        uses: github/codeql-action/upload-sarif@cb06a0a8527b2c6970741b3a0baa15231dc74a4c # v4.34.1
+        uses: github/codeql-action/upload-sarif@38697555549f1db7851b81482ff19f1fa5c4fedc # v4.34.1
         if: always() && hashFiles('snyk-code.sarif') != ''
         with:
           sarif_file: snyk-code.sarif

--- a/.github/workflows/sonar.yml
+++ b/.github/workflows/sonar.yml
@@ -17,12 +17,12 @@ jobs:
       pull-requests: read
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
         with:
           fetch-depth: 0
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@39cd14951b08e74b54015e9e001cdefcf80e669f # v5.1.1
         with:
           python-version: '3.11'
 
@@ -37,7 +37,7 @@ jobs:
           pytest --cov=qwed_finance --cov-report=xml --cov-report=term-missing tests/
 
       - name: SonarCloud Scan
-        uses: SonarSource/sonarqube-scan-action@689fb39b34b9aa95ebc5f8f119343ddd51542402 # v4
+        uses: SonarSource/sonarqube-scan-action@a31c9398be7ace6bbfaf30c0bd5d415f843d45e9 # v7.0.0
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -12,10 +12,10 @@ jobs:
     permissions:
       contents: read
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@39cd14951b08e74b54015e9e001cdefcf80e669f # v5.1.1
         with:
           python-version: '3.11'
 
@@ -30,7 +30,7 @@ jobs:
 
       - name: Upload coverage reports to Codecov
         if: ${{ github.event_name != 'pull_request' || !github.event.pull_request.head.repo.fork }}
-        uses: codecov/codecov-action@v5
+        uses: codecov/codecov-action@0561704f0f02c16a585d4c7555e57fa2e44cf909 # v5.5.2
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           slug: QWED-AI/qwed-finance


### PR DESCRIPTION
## Security Hardening: CI/CD Pipeline SHA Pinning

### 🔒 Description
This PR elevates the supply-chain security of the repository by replacing completely mutable version tags (e.g., `@v4`, `@v5`) with strictly verified cryptographic SHA-1 commit hashes for all external GitHub Actions. This mitigates potential vector attacks such as tag-hijacking and ensures deterministic behavior across our testing, publishing, and security workflows.

### 🛠️ Key Changes
- **Action Pinning:** 
  - `actions/checkout` securely pinned to `v4.1.7` SHA (avoids unverified v6 major upgrades).
  - `actions/setup-python` securely pinned to `v5.1.1` SHA.
- **Snyk Integration:** Hardcoded the Snyk CLI installation to the recommended hotfix (`npm install -g snyk@1.1303.2`) to prevent floating runner dependency drift.
- **SonarQube Migration:** Decoupled from the deprecated `sonarcloud-github-action` and migrated to the verified and officially supported `SonarSource/sonarqube-scan-action@v7.0.0` SHA.
- **CodeQL Integration:** Pinned all `github/codeql-action` instances to the verified `v4.34.1` SHA (avoids unreleased version tags).
- **Codecov Upload:** Safely pinned `codecov-action` to `v5.5.2` (avoids major Node v24 runtime breaking changes introduced in v6).
- Retained human-readable tags as comments (`# vX.Y.Z`) for easier life-cycle management.

### ✅ Verification
- Analyzed existing workflow files across all critical workflows (`publish.yml`, `ci.yml`, `sonar.yml`, `snyk.yml`).
- Explicitly addressed the CodeRabbit findings and factored in strict Sentry security rules for safe non-breaking versions.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Pinned CI/CD workflow actions to fixed revisions across repository workflows to improve build stability and reproducibility.
  * Updated scanning, upload, and test tooling versions used by workflows to ensure consistent pipeline behavior.
  * No runtime or product-facing behavior was changed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->