### PR TITLE
fix(integrations): enforce fail-closed default and COMPUTED status in OpenResponsesIntegration

### DIFF
--- a/qwed_finance/integrations/open_responses.py
+++ b/qwed_finance/integrations/open_responses.py
@@ -17,10 +17,11 @@ from ..models.receipt import VerificationReceipt, ReceiptGenerator, Verification
 
 class ToolCallStatus(Enum):
     """Status of a verified tool call"""
-    APPROVED = "approved"
-    REJECTED = "rejected"
-    MODIFIED = "modified"
-    ERROR = "error"
+    APPROVED = "approved"      # Verified against LLM claim and passed
+    REJECTED = "rejected"      # Verification failed or not possible
+    MODIFIED = "modified"      # Args were corrected before approval
+    COMPUTED = "computed"      # Result computed but NOT verified against LLM claim
+    ERROR = "error"            # System error prevented verification
 
 
 @dataclass
@@ -215,56 +216,65 @@ class OpenResponsesIntegration:
         if tool.verification_fn:
             return tool.verification_fn(args)
         
-        # Default: approve without verification
+        # Fail-closed: reject tools without a verification function.
+        # QWED philosophy: "Verification decides IF." — no verification = no approval.
         return VerifiedToolCall(
-            status=ToolCallStatus.APPROVED,
+            status=ToolCallStatus.REJECTED,
             tool_name=tool_name,
             original_args=args,
-            verified_args=args
+            error=(
+                f"No verification function registered for tool '{tool_name}'. "
+                "All tools must have a verification_fn to be approved."
+            ),
+            retry_message=(
+                "Register a verification function using register_tool() "
+                "with a verification_fn parameter."
+            )
         )
     
     # ==================== Verification Functions ====================
     
     def _verify_npv(self, args: Dict[str, Any]) -> VerifiedToolCall:
-        """Verify NPV calculation"""
+        """Compute NPV — returns COMPUTED status (not verified against LLM claim)."""
         cashflows = args.get("cashflows", [])
         rate = args.get("rate", 0)
         
-        # Compute NPV
-        from decimal import Decimal
+        # Compute NPV using Decimal for exact arithmetic
+        from decimal import Decimal, ROUND_HALF_UP
         npv = Decimal('0')
         for t, cf in enumerate(cashflows):
             npv += Decimal(str(cf)) / (Decimal(str(1 + rate)) ** t)
         
-        result = f"${float(npv):.2f}"
+        computed_npv = str(npv.quantize(Decimal('0.01'), rounding=ROUND_HALF_UP))
+        result = f"${computed_npv}"
         
         receipt = ReceiptGenerator.create_receipt(
             guard_name="OpenResponses.calculate_npv",
             engine=VerificationEngine.SYMPY,
             llm_output=str(args),
-            verified=True,
+            verified=False,  # Computed, not verified against LLM claim
             computed_value=result,
             formula="NPV = Σ(CFt / (1+r)^t)"
         )
         self.audit_log.log(receipt)
         
         return VerifiedToolCall(
-            status=ToolCallStatus.APPROVED,
+            status=ToolCallStatus.COMPUTED,
             tool_name="calculate_npv",
             original_args=args,
             verified_args=args,
-            result={"npv": result, "verified": True},
+            result={"npv": result, "computed": True, "verified_against_llm": False},
             receipt=receipt
         )
     
     def _verify_loan_payment(self, args: Dict[str, Any]) -> VerifiedToolCall:
-        """Verify loan payment calculation"""
+        """Compute loan payment — returns COMPUTED status (not verified against LLM claim)."""
         principal = args.get("principal", 0)
         annual_rate = args.get("annual_rate", 0)
         months = args.get("months", 1)
         
-        # Compute payment
-        from decimal import Decimal
+        # Compute payment using Decimal for exact arithmetic
+        from decimal import Decimal, ROUND_HALF_UP
         P = Decimal(str(principal))
         monthly_rate = Decimal(str(annual_rate)) / 12
         n = months
@@ -276,49 +286,51 @@ class OpenResponsesIntegration:
             one_plus_r_n = one_plus_r ** n
             payment = P * (monthly_rate * one_plus_r_n) / (one_plus_r_n - 1)
         
-        result = f"${float(payment):.2f}"
+        computed_payment = str(payment.quantize(Decimal('0.01'), rounding=ROUND_HALF_UP))
+        result = f"${computed_payment}"
         
         receipt = ReceiptGenerator.create_receipt(
             guard_name="OpenResponses.calculate_loan_payment",
             engine=VerificationEngine.SYMPY,
             llm_output=str(args),
-            verified=True,
+            verified=False,  # Computed, not verified against LLM claim
             computed_value=result,
             formula="PMT = P × [r(1+r)^n] / [(1+r)^n - 1]"
         )
         self.audit_log.log(receipt)
         
         return VerifiedToolCall(
-            status=ToolCallStatus.APPROVED,
+            status=ToolCallStatus.COMPUTED,
             tool_name="calculate_loan_payment",
             original_args=args,
             verified_args=args,
-            result={"monthly_payment": result, "verified": True},
+            result={"monthly_payment": result, "computed": True, "verified_against_llm": False},
             receipt=receipt
         )
     
     def _verify_aml(self, args: Dict[str, Any]) -> VerifiedToolCall:
-        """Verify AML compliance check"""
+        """Compute AML check — delegates to ComplianceGuard for consistent rules."""
         amount = args.get("amount", 0)
         country_code = args.get("country_code", "US")
         
-        # Check AML threshold
-        threshold = 10000
-        is_high_risk = country_code.upper() in {"KP", "IR", "SY", "MM", "AF"}
+        # Delegate to ComplianceGuard for consistent high-risk country list
+        # (S-06 fix: no more duplicated subset of countries)
+        is_high_risk = country_code.upper() in self.compliance.high_risk_countries
+        threshold = self.compliance.aml_thresholds.get("USA", 10000)
         needs_flagging = amount >= threshold or is_high_risk
         
         receipt = ReceiptGenerator.create_receipt(
             guard_name="OpenResponses.check_aml_compliance",
             engine=VerificationEngine.Z3,
             llm_output=str(args),
-            verified=True,
+            verified=False,  # Computed, not verified against LLM claim
             computed_value=str(needs_flagging),
-            formula="Flag if: amount >= $10,000 OR country in HIGH_RISK"
+            formula="Flag if: amount >= threshold OR country in HIGH_RISK"
         )
         self.audit_log.log(receipt)
         
         return VerifiedToolCall(
-            status=ToolCallStatus.APPROVED,
+            status=ToolCallStatus.COMPUTED,
             tool_name="check_aml_compliance",
             original_args=args,
             verified_args=args,
@@ -326,14 +338,15 @@ class OpenResponsesIntegration:
                 "needs_flagging": needs_flagging,
                 "reason": "Amount exceeds threshold" if amount >= threshold else
                          "High-risk jurisdiction" if is_high_risk else "Clear",
-                "verified": True
+                "computed": True,
+                "verified_against_llm": False
             },
             receipt=receipt
         )
     
     def _verify_option_price(self, args: Dict[str, Any]) -> VerifiedToolCall:
-        """Verify Black-Scholes option price"""
-        from .derivatives_guard import OptionType
+        """Compute Black-Scholes option price — returns COMPUTED status."""
+        from ..derivatives_guard import OptionType
         import math
         
         S = args.get("spot_price", 100)
@@ -359,21 +372,22 @@ class OpenResponsesIntegration:
             guard_name="OpenResponses.price_option",
             engine=VerificationEngine.SYMPY,
             llm_output=str(args),
-            verified=True,
+            verified=False,  # Computed, not verified against LLM claim
             computed_value=f"${price:.2f}",
             formula="Black-Scholes: C = S·N(d₁) - K·e^(-rT)·N(d₂)"
         )
         self.audit_log.log(receipt)
         
         return VerifiedToolCall(
-            status=ToolCallStatus.APPROVED,
+            status=ToolCallStatus.COMPUTED,
             tool_name="price_option",
             original_args=args,
             verified_args=args,
             result={
                 "price": f"${price:.2f}",
                 "delta": round(norm_cdf(d1) if opt_type == OptionType.CALL else norm_cdf(d1) - 1, 4),
-                "verified": True
+                "computed": True,
+                "verified_against_llm": False
             },
             receipt=receipt
         )
@@ -402,10 +416,34 @@ class OpenResponsesIntegration:
                     "text": json.dumps({
                         "result": result.result,
                         "verification": {
+                            "status": "verified",
                             "verified": True,
                             "engine": result.receipt.engine_used.value if result.receipt else "unknown",
                             "receipt_id": result.receipt.receipt_id if result.receipt else None,
                             "input_hash": result.receipt.input_hash if result.receipt else None,
+                            "timestamp": result.receipt.timestamp if result.receipt else None
+                        }
+                    })
+                },
+                "is_error": False
+            }
+        elif result.status == ToolCallStatus.COMPUTED:
+            # COMPUTED: result is available but was NOT verified against an LLM claim.
+            # Downstream consumers must NOT treat this as "verified".
+            return {
+                "type": "tool_result",
+                "id": call_id,
+                "tool_use_id": result.tool_name,
+                "content": {
+                    "mime_type": "application/json",
+                    "text": json.dumps({
+                        "result": result.result,
+                        "verification": {
+                            "status": "computed_only",
+                            "verified": False,
+                            "note": "Result was computed deterministically but NOT verified against an LLM claim.",
+                            "engine": result.receipt.engine_used.value if result.receipt else "unknown",
+                            "receipt_id": result.receipt.receipt_id if result.receipt else None,
                             "timestamp": result.receipt.timestamp if result.receipt else None
                         }
                     })

--- a/qwed_finance/integrations/open_responses.py
+++ b/qwed_finance/integrations/open_responses.py
@@ -214,14 +214,34 @@ class OpenResponsesIntegration:
         
         # If tool has verification function, use it
         if tool.verification_fn:
-            return tool.verification_fn(args)
+            try:
+                return tool.verification_fn(args)
+            except Exception as e:
+                return VerifiedToolCall(
+                    status=ToolCallStatus.ERROR,
+                    tool_name=tool_name,
+                    original_args=args,
+                    error=f"Verification function failed: {e}",
+                    retry_message="Please retry with valid arguments or investigate tool verifier errors.",
+                )
         
         # Fail-closed: reject tools without a verification function.
         # QWED philosophy: "Verification decides IF." — no verification = no approval.
+        receipt = ReceiptGenerator.create_receipt(
+            guard_name=f"OpenResponses.{tool_name}",
+            engine=VerificationEngine.DECIMAL,
+            llm_output=str(args),
+            verified=False,
+            computed_value="rejected_missing_verification_fn",
+            violations=[f"No verification function registered for tool '{tool_name}'"],
+        )
+        self.audit_log.log(receipt)
+
         return VerifiedToolCall(
             status=ToolCallStatus.REJECTED,
             tool_name=tool_name,
             original_args=args,
+            receipt=receipt,
             error=(
                 f"No verification function registered for tool '{tool_name}'. "
                 "All tools must have a verification_fn to be approved."
@@ -263,7 +283,7 @@ class OpenResponsesIntegration:
             tool_name="calculate_npv",
             original_args=args,
             verified_args=args,
-            result={"npv": result, "computed": True, "verified_against_llm": False},
+            result={"npv": result, "verified": False, "computed": True, "verified_against_llm": False},
             receipt=receipt
         )
     
@@ -295,7 +315,7 @@ class OpenResponsesIntegration:
             llm_output=str(args),
             verified=False,  # Computed, not verified against LLM claim
             computed_value=result,
-            formula="PMT = P × [r(1+r)^n] / [(1+r)^n - 1]"
+            formula="PMT = P * [r(1+r)^n] / [(1+r)^n - 1]"
         )
         self.audit_log.log(receipt)
         
@@ -304,7 +324,7 @@ class OpenResponsesIntegration:
             tool_name="calculate_loan_payment",
             original_args=args,
             verified_args=args,
-            result={"monthly_payment": result, "computed": True, "verified_against_llm": False},
+            result={"monthly_payment": result, "verified": False, "computed": True, "verified_against_llm": False},
             receipt=receipt
         )
     
@@ -338,6 +358,7 @@ class OpenResponsesIntegration:
                 "needs_flagging": needs_flagging,
                 "reason": "Amount exceeds threshold" if amount >= threshold else
                          "High-risk jurisdiction" if is_high_risk else "Clear",
+                "verified": False,
                 "computed": True,
                 "verified_against_llm": False
             },
@@ -355,6 +376,16 @@ class OpenResponsesIntegration:
         r = args.get("risk_free_rate", 0.05)
         sigma = args.get("volatility", 0.2)
         opt_type = OptionType.CALL if args.get("option_type") == "call" else OptionType.PUT
+        
+        # Fail-closed: reject non-positive inputs that would cause math errors
+        if S <= 0 or K <= 0 or T <= 0 or sigma <= 0:
+            return VerifiedToolCall(
+                status=ToolCallStatus.REJECTED,
+                tool_name="price_option",
+                original_args=args,
+                error="spot_price, strike_price, time_to_expiry, and volatility must be > 0",
+                retry_message="Provide strictly positive inputs for Black-Scholes pricing.",
+            )
         
         # Black-Scholes
         d1 = (math.log(S / K) + (r + (sigma ** 2) / 2) * T) / (sigma * math.sqrt(T))
@@ -386,12 +417,64 @@ class OpenResponsesIntegration:
             result={
                 "price": f"${price:.2f}",
                 "delta": round(norm_cdf(d1) if opt_type == OptionType.CALL else norm_cdf(d1) - 1, 4),
+                "verified": False,
                 "computed": True,
                 "verified_against_llm": False
             },
             receipt=receipt
         )
     
+    @staticmethod
+    def _extract_receipt_meta(
+        receipt: Optional[VerificationReceipt],
+    ) -> Dict[str, Any]:
+        """Extract common metadata from a receipt (or safe defaults)."""
+        if receipt is None:
+            return {"engine": "unknown", "receipt_id": None, "timestamp": None, "input_hash": None}
+        return {
+            "engine": receipt.engine_used.value,
+            "receipt_id": receipt.receipt_id,
+            "input_hash": receipt.input_hash,
+            "timestamp": receipt.timestamp,
+        }
+
+    def _format_success(
+        self, call_id: str, result: VerifiedToolCall, verification: Dict[str, Any],
+    ) -> Dict[str, Any]:
+        """Format a non-error tool result item."""
+        return {
+            "type": "tool_result",
+            "id": call_id,
+            "tool_use_id": result.tool_name,
+            "content": {
+                "mime_type": "application/json",
+                "text": json.dumps({
+                    "result": result.result,
+                    "verification": verification,
+                }),
+            },
+            "is_error": False,
+        }
+
+    def _format_error(
+        self, call_id: str, result: VerifiedToolCall,
+    ) -> Dict[str, Any]:
+        """Format an error tool result item."""
+        return {
+            "type": "tool_result",
+            "id": call_id,
+            "tool_use_id": result.tool_name,
+            "content": {
+                "mime_type": "application/json",
+                "text": json.dumps({
+                    "error": result.error,
+                    "retry_message": result.retry_message,
+                    "violations": result.receipt.violations if result.receipt else [],
+                }),
+            },
+            "is_error": True,
+        }
+
     def format_for_responses_api(
         self, 
         result: VerifiedToolCall,
@@ -405,66 +488,26 @@ class OpenResponsesIntegration:
         import uuid
         
         call_id = tool_call_id or f"call_{uuid.uuid4().hex[:12]}"
+        meta = self._extract_receipt_meta(result.receipt)
         
         if result.status == ToolCallStatus.APPROVED:
-            return {
-                "type": "tool_result",
-                "id": call_id,
-                "tool_use_id": result.tool_name,
-                "content": {
-                    "mime_type": "application/json",
-                    "text": json.dumps({
-                        "result": result.result,
-                        "verification": {
-                            "status": "verified",
-                            "verified": True,
-                            "engine": result.receipt.engine_used.value if result.receipt else "unknown",
-                            "receipt_id": result.receipt.receipt_id if result.receipt else None,
-                            "input_hash": result.receipt.input_hash if result.receipt else None,
-                            "timestamp": result.receipt.timestamp if result.receipt else None
-                        }
-                    })
-                },
-                "is_error": False
-            }
-        elif result.status == ToolCallStatus.COMPUTED:
+            return self._format_success(call_id, result, {
+                "status": "verified",
+                "verified": True,
+                **meta,
+            })
+
+        if result.status == ToolCallStatus.COMPUTED:
             # COMPUTED: result is available but was NOT verified against an LLM claim.
             # Downstream consumers must NOT treat this as "verified".
-            return {
-                "type": "tool_result",
-                "id": call_id,
-                "tool_use_id": result.tool_name,
-                "content": {
-                    "mime_type": "application/json",
-                    "text": json.dumps({
-                        "result": result.result,
-                        "verification": {
-                            "status": "computed_only",
-                            "verified": False,
-                            "note": "Result was computed deterministically but NOT verified against an LLM claim.",
-                            "engine": result.receipt.engine_used.value if result.receipt else "unknown",
-                            "receipt_id": result.receipt.receipt_id if result.receipt else None,
-                            "timestamp": result.receipt.timestamp if result.receipt else None
-                        }
-                    })
-                },
-                "is_error": False
-            }
-        else:
-            return {
-                "type": "tool_result",
-                "id": call_id,
-                "tool_use_id": result.tool_name,
-                "content": {
-                    "mime_type": "application/json",
-                    "text": json.dumps({
-                        "error": result.error,
-                        "retry_message": result.retry_message,
-                        "violations": result.receipt.violations if result.receipt else []
-                    })
-                },
-                "is_error": True
-            }
+            return self._format_success(call_id, result, {
+                "status": "computed_only",
+                "verified": False,
+                "note": "Result was computed deterministically but NOT verified against an LLM claim.",
+                **meta,
+            })
+
+        return self._format_error(call_id, result)
     
     def format_as_item(
         self,

--- a/tests/test_open_responses.py
+++ b/tests/test_open_responses.py
@@ -1,0 +1,289 @@
+"""
+Tests for OpenResponsesIntegration fail-closed behavior.
+
+Covers:
+- S-01: Tools without verification_fn must be REJECTED (not APPROVED)
+- S-02: Built-in verification functions must use COMPUTED status (not APPROVED)
+- S-06: AML high-risk country list must match ComplianceGuard
+"""
+
+import pytest
+from qwed_finance.integrations.open_responses import (
+    OpenResponsesIntegration,
+    ToolCallStatus,
+    VerifiedToolCall,
+)
+from qwed_finance.compliance_guard import ComplianceGuard
+
+
+class TestFailClosedDefault:
+    """S-01: Tools without verification_fn must be REJECTED."""
+
+    def setup_method(self):
+        self.integration = OpenResponsesIntegration()
+
+    def test_unregistered_tool_returns_error(self):
+        """Calling a tool that doesn't exist returns ERROR."""
+        result = self.integration.handle_tool_call(
+            "nonexistent_tool", {"foo": "bar"}
+        )
+        assert result.status == ToolCallStatus.ERROR
+        assert "Unknown tool" in result.error
+
+    def test_tool_without_verification_fn_is_rejected(self):
+        """S-01: A tool registered without verification_fn must be REJECTED."""
+        self.integration.register_tool(
+            name="transfer_funds",
+            description="Transfer money between accounts",
+            parameters={"amount": {"type": "number"}},
+            # NO verification_fn
+        )
+
+        result = self.integration.handle_tool_call(
+            "transfer_funds", {"amount": 999999999}
+        )
+
+        assert result.status == ToolCallStatus.REJECTED
+        assert result.error is not None
+        assert "verification function" in result.error.lower()
+        assert result.verified_args is None
+
+    def test_tool_without_verification_fn_has_no_receipt(self):
+        """Rejected tools should not produce audit receipts."""
+        self.integration.register_tool(
+            name="dangerous_tool",
+            description="No verification",
+            parameters={},
+        )
+
+        result = self.integration.handle_tool_call(
+            "dangerous_tool", {"action": "delete_everything"}
+        )
+
+        assert result.status == ToolCallStatus.REJECTED
+        assert result.receipt is None
+
+    def test_tool_with_verification_fn_is_not_rejected(self):
+        """A tool WITH verification_fn should not be REJECTED."""
+        def dummy_verify(args):
+            return VerifiedToolCall(
+                status=ToolCallStatus.APPROVED,
+                tool_name="safe_tool",
+                original_args=args,
+                verified_args=args,
+            )
+
+        self.integration.register_tool(
+            name="safe_tool",
+            description="Has verification",
+            parameters={},
+            verification_fn=dummy_verify,
+        )
+
+        result = self.integration.handle_tool_call("safe_tool", {"x": 1})
+        assert result.status == ToolCallStatus.APPROVED
+
+    def test_invalid_json_returns_error(self):
+        """Malformed JSON arguments return ERROR."""
+        result = self.integration.handle_tool_call(
+            "calculate_npv", "not valid json{{"
+        )
+        assert result.status == ToolCallStatus.ERROR
+        assert "Invalid JSON" in result.error
+
+
+class TestComputedStatus:
+    """S-02: Built-in functions must return COMPUTED, not APPROVED."""
+
+    def setup_method(self):
+        self.integration = OpenResponsesIntegration()
+
+    def test_npv_returns_computed(self):
+        """NPV tool call must return COMPUTED status."""
+        result = self.integration.handle_tool_call(
+            "calculate_npv",
+            {"cashflows": [-1000, 300, 400, 500], "rate": 0.1},
+        )
+
+        assert result.status == ToolCallStatus.COMPUTED
+        assert result.result is not None
+        assert result.result["computed"] is True
+        assert result.result["verified_against_llm"] is False
+
+    def test_npv_receipt_not_verified(self):
+        """NPV receipt must show verified=False."""
+        result = self.integration.handle_tool_call(
+            "calculate_npv",
+            {"cashflows": [-1000, 300, 400, 500], "rate": 0.1},
+        )
+
+        assert result.receipt is not None
+        assert result.receipt.verified is False
+
+    def test_loan_payment_returns_computed(self):
+        """Loan payment tool call must return COMPUTED status."""
+        result = self.integration.handle_tool_call(
+            "calculate_loan_payment",
+            {"principal": 100000, "annual_rate": 0.06, "months": 360},
+        )
+
+        assert result.status == ToolCallStatus.COMPUTED
+        assert result.result["computed"] is True
+        assert result.result["verified_against_llm"] is False
+        assert result.receipt.verified is False
+
+    def test_aml_returns_computed(self):
+        """AML check tool call must return COMPUTED status."""
+        result = self.integration.handle_tool_call(
+            "check_aml_compliance",
+            {"amount": 15000, "country_code": "US"},
+        )
+
+        assert result.status == ToolCallStatus.COMPUTED
+        assert result.result["computed"] is True
+        assert result.result["verified_against_llm"] is False
+        assert result.receipt.verified is False
+
+    def test_option_price_returns_computed(self):
+        """Option pricing tool call must return COMPUTED status."""
+        result = self.integration.handle_tool_call(
+            "price_option",
+            {
+                "spot_price": 100,
+                "strike_price": 105,
+                "time_to_expiry": 0.5,
+                "risk_free_rate": 0.05,
+                "volatility": 0.2,
+                "option_type": "call",
+            },
+        )
+
+        assert result.status == ToolCallStatus.COMPUTED
+        assert result.result["computed"] is True
+        assert result.result["verified_against_llm"] is False
+        assert result.receipt.verified is False
+
+    def test_no_builtin_tool_returns_approved(self):
+        """No built-in tool should return APPROVED (they only compute)."""
+        builtin_tools = [
+            ("calculate_npv", {"cashflows": [-100, 50, 60], "rate": 0.1}),
+            ("calculate_loan_payment", {"principal": 10000, "annual_rate": 0.05, "months": 12}),
+            ("check_aml_compliance", {"amount": 5000, "country_code": "US"}),
+            ("price_option", {
+                "spot_price": 100, "strike_price": 100,
+                "time_to_expiry": 1, "risk_free_rate": 0.05,
+                "volatility": 0.2, "option_type": "call",
+            }),
+        ]
+
+        for tool_name, args in builtin_tools:
+            result = self.integration.handle_tool_call(tool_name, args)
+            assert result.status != ToolCallStatus.APPROVED, (
+                f"{tool_name} returned APPROVED but should return COMPUTED"
+            )
+
+
+class TestAMLCountryConsistency:
+    """S-06: Integration must use same country list as ComplianceGuard."""
+
+    def setup_method(self):
+        self.integration = OpenResponsesIntegration()
+        self.compliance = ComplianceGuard()
+
+    def test_yemen_flagged_via_integration(self):
+        """Yemen (YE) must be flagged via integration path."""
+        result = self.integration.handle_tool_call(
+            "check_aml_compliance",
+            {"amount": 5000, "country_code": "YE"},
+        )
+        assert result.result["needs_flagging"] is True
+
+    def test_venezuela_flagged_via_integration(self):
+        """Venezuela (VE) must be flagged via integration path."""
+        result = self.integration.handle_tool_call(
+            "check_aml_compliance",
+            {"amount": 5000, "country_code": "VE"},
+        )
+        assert result.result["needs_flagging"] is True
+
+    def test_pakistan_flagged_via_integration(self):
+        """Pakistan (PK) must be flagged via integration path."""
+        result = self.integration.handle_tool_call(
+            "check_aml_compliance",
+            {"amount": 5000, "country_code": "PK"},
+        )
+        assert result.result["needs_flagging"] is True
+
+    def test_all_high_risk_countries_match(self):
+        """Every country in ComplianceGuard.high_risk_countries must be flagged."""
+        for country in self.compliance.high_risk_countries:
+            result = self.integration.handle_tool_call(
+                "check_aml_compliance",
+                {"amount": 1, "country_code": country},  # Below $ threshold
+            )
+            assert result.result["needs_flagging"] is True, (
+                f"Country {country} not flagged via integration but is in "
+                f"ComplianceGuard.high_risk_countries"
+            )
+
+    def test_safe_country_not_flagged(self):
+        """A safe country below threshold should NOT be flagged."""
+        result = self.integration.handle_tool_call(
+            "check_aml_compliance",
+            {"amount": 5000, "country_code": "US"},
+        )
+        assert result.result["needs_flagging"] is False
+
+
+class TestFormatForResponsesAPI:
+    """Verify format_for_responses_api handles COMPUTED correctly."""
+
+    def setup_method(self):
+        self.integration = OpenResponsesIntegration()
+
+    def test_computed_result_shows_computed_only_status(self):
+        """COMPUTED results must show status='computed_only' in output."""
+        result = self.integration.handle_tool_call(
+            "calculate_npv",
+            {"cashflows": [-100, 50, 60], "rate": 0.1},
+        )
+
+        formatted = self.integration.format_for_responses_api(result)
+
+        assert formatted["is_error"] is False
+        import json
+        content = json.loads(formatted["content"]["text"])
+        assert content["verification"]["status"] == "computed_only"
+        assert content["verification"]["verified"] is False
+
+    def test_rejected_result_is_error(self):
+        """REJECTED results must be flagged as errors."""
+        self.integration.register_tool(
+            name="unverified_tool",
+            description="No verification",
+            parameters={},
+        )
+        result = self.integration.handle_tool_call("unverified_tool", {})
+        formatted = self.integration.format_for_responses_api(result)
+
+        assert formatted["is_error"] is True
+
+
+class TestNPVPrecision:
+    """Verify NPV output preserves Decimal precision (S-04 partial fix)."""
+
+    def setup_method(self):
+        self.integration = OpenResponsesIntegration()
+
+    def test_npv_no_float_in_output(self):
+        """NPV result string must not exhibit float artifacts like 0.30000000000000004."""
+        result = self.integration.handle_tool_call(
+            "calculate_npv",
+            {"cashflows": [-100, 50, 60], "rate": 0.1},
+        )
+
+        npv_str = result.result["npv"]
+        # Should be clean like "$1.23", not "$1.2300000000000001"
+        assert "000000" not in npv_str, (
+            f"Float precision leak detected in NPV output: {npv_str}"
+        )

--- a/tests/test_open_responses.py
+++ b/tests/test_open_responses.py
@@ -7,7 +7,9 @@ Covers:
 - S-06: AML high-risk country list must match ComplianceGuard
 """
 
-import pytest
+
+import re
+
 from qwed_finance.integrations.open_responses import (
     OpenResponsesIntegration,
     ToolCallStatus,
@@ -48,8 +50,8 @@ class TestFailClosedDefault:
         assert "verification function" in result.error.lower()
         assert result.verified_args is None
 
-    def test_tool_without_verification_fn_has_no_receipt(self):
-        """Rejected tools should not produce audit receipts."""
+    def test_tool_without_verification_fn_has_audit_receipt(self):
+        """Rejected tools should produce audit receipts for compliance."""
         self.integration.register_tool(
             name="dangerous_tool",
             description="No verification",
@@ -61,7 +63,8 @@ class TestFailClosedDefault:
         )
 
         assert result.status == ToolCallStatus.REJECTED
-        assert result.receipt is None
+        assert result.receipt is not None
+        assert result.receipt.verified is False
 
     def test_tool_with_verification_fn_is_not_rejected(self):
         """A tool WITH verification_fn should not be REJECTED."""
@@ -178,8 +181,8 @@ class TestComputedStatus:
 
         for tool_name, args in builtin_tools:
             result = self.integration.handle_tool_call(tool_name, args)
-            assert result.status != ToolCallStatus.APPROVED, (
-                f"{tool_name} returned APPROVED but should return COMPUTED"
+            assert result.status == ToolCallStatus.COMPUTED, (
+                f"{tool_name} returned {result.status} but should return COMPUTED"
             )
 
 
@@ -283,7 +286,74 @@ class TestNPVPrecision:
         )
 
         npv_str = result.result["npv"]
-        # Should be clean like "$1.23", not "$1.2300000000000001"
-        assert "000000" not in npv_str, (
-            f"Float precision leak detected in NPV output: {npv_str}"
+        # Should be currency-formatted with exactly 2 decimal places
+        assert re.fullmatch(r"\$-?\d+\.\d{2}", npv_str), (
+            f"Unexpected NPV currency format (possible precision leak): {npv_str}"
         )
+
+
+class TestVerificationFnErrorBoundary:
+    """Verify that a crashing verification_fn returns ERROR, not exception."""
+
+    def setup_method(self):
+        self.integration = OpenResponsesIntegration()
+
+    def test_crashing_verification_fn_returns_error(self):
+        """A verification_fn that raises should return ERROR status."""
+        def crashing_verify(args):
+            raise ValueError("Something went wrong")
+
+        self.integration.register_tool(
+            name="crashing_tool",
+            description="Will crash",
+            parameters={},
+            verification_fn=crashing_verify,
+        )
+
+        result = self.integration.handle_tool_call("crashing_tool", {"x": 1})
+        assert result.status == ToolCallStatus.ERROR
+        assert "Verification function failed" in result.error
+
+
+class TestBlackScholesInputGuard:
+    """Verify Black-Scholes rejects zero/negative inputs."""
+
+    def setup_method(self):
+        self.integration = OpenResponsesIntegration()
+
+    def test_zero_volatility_rejected(self):
+        """Volatility=0 would cause ZeroDivisionError — must be REJECTED."""
+        result = self.integration.handle_tool_call(
+            "price_option",
+            {
+                "spot_price": 100, "strike_price": 100,
+                "time_to_expiry": 1, "risk_free_rate": 0.05,
+                "volatility": 0, "option_type": "call",
+            },
+        )
+        assert result.status == ToolCallStatus.REJECTED
+        assert "must be > 0" in result.error
+
+    def test_zero_time_rejected(self):
+        """time_to_expiry=0 would cause ZeroDivisionError — must be REJECTED."""
+        result = self.integration.handle_tool_call(
+            "price_option",
+            {
+                "spot_price": 100, "strike_price": 100,
+                "time_to_expiry": 0, "risk_free_rate": 0.05,
+                "volatility": 0.2, "option_type": "call",
+            },
+        )
+        assert result.status == ToolCallStatus.REJECTED
+
+    def test_negative_spot_rejected(self):
+        """Negative spot price is nonsensical — must be REJECTED."""
+        result = self.integration.handle_tool_call(
+            "price_option",
+            {
+                "spot_price": -100, "strike_price": 100,
+                "time_to_expiry": 1, "risk_free_rate": 0.05,
+                "volatility": 0.2, "option_type": "call",
+            },
+        )
+        assert result.status == ToolCallStatus.REJECTED


### PR DESCRIPTION
## Summary

Fixes the two most critical findings from the QWED Finance Phase 1 + Phase 2 security audit: **S-01 (fail-open default)** and **S-02 (fake verification status)**, plus partially addresses **S-06 (AML country divergence)** and **S-04 (Decimal→float precision leak)**.

> *"Verification decides IF. Risk decides HOW."*
> No verification happened → system must not say `APPROVED`.

---

## Changes

### 1. Fail-Closed Default (S-01)

**Before:** Tools registered without `verification_fn` were auto-`APPROVED`:

```python
# Default: approve without verification
return VerifiedToolCall(status=ToolCallStatus.APPROVED, ...)
```

**After:** Default is now `REJECTED` with a clear error message:

```python
# Fail-closed: reject tools without a verification function.
return VerifiedToolCall(status=ToolCallStatus.REJECTED, ...)
```

---

### 2. COMPUTED Status (S-02)

**Before:** All 4 built-in verification functions hardcoded `verified=True` and `status=APPROVED` — even though they only **compute** results without comparing against any LLM claim.

**After:** New `ToolCallStatus.COMPUTED` status distinguishes "we computed this" from "we verified an LLM claim":

```python
class ToolCallStatus(Enum):
    APPROVED = "approved"   # Verified against LLM claim and passed
    REJECTED = "rejected"   # Verification failed or not possible
    MODIFIED = "modified"   # Args were corrected before approval
    COMPUTED = "computed"   # Result computed but NOT verified against LLM claim
    ERROR    = "error"      # System error prevented verification
```

All 4 built-in functions (`_verify_npv`, `_verify_loan_payment`, `_verify_aml`, `_verify_option_price`) now return `COMPUTED`.

---

### 3. AML Country Consistency (S-06)

**Before:** Integration hardcoded 5 high-risk countries while ComplianceGuard had 14:

```python
is_high_risk = country_code.upper() in {"KP", "IR", "SY", "MM", "AF"}
```

**After:** Delegates to `ComplianceGuard.high_risk_countries` for single source of truth:

```python
is_high_risk = country_code.upper() in self.compliance.high_risk_countries
```

---

### 4. Precision Preservation (S-04 partial)

**Before:** NPV/loan computed in `Decimal` then leaked to `float`:

```python
result = f"${float(npv):.2f}"
```

**After:** Uses `Decimal.quantize()` to preserve precision:

```python
computed_npv = str(npv.quantize(Decimal('0.01'), rounding=ROUND_HALF_UP))
result = f"${computed_npv}"
```

---

### 5. API Output Format

`format_for_responses_api()` now handles `COMPUTED` status explicitly:

| Status | `"status"` field | `"verified"` |
|---|---|---|
| `APPROVED` | `"verified"` | `true` |
| `COMPUTED` | `"computed_only"` | `false` |
| `REJECTED` / `ERROR` | — | `"is_error": true` |

---

## Breaking Changes

⚠️ **`ToolCallStatus.COMPUTED` is new** — downstream consumers checking `status == APPROVED` will need to handle `COMPUTED` as a valid non-error state.

⚠️ **Tools without `verification_fn` now return `REJECTED`** — any tool registered without verification must add one.

---

## Test Coverage

19 new tests in `tests/test_open_responses.py`:

| Test Class | Count | Covers |
|---|---|---|
| `TestFailClosedDefault` | 5 | S-01: Unverified tools rejected |
| `TestComputedStatus` | 6 | S-02: All builtins return COMPUTED |
| `TestAMLCountryConsistency` | 5 | S-06: All 14 countries flagged |
| `TestFormatForResponsesAPI` | 2 | COMPUTED format output |
| `TestNPVPrecision` | 1 | S-04: No float leak in output |

**All 65 tests pass** (19 new + 46 existing, zero regressions).

---

## Linked Issues

- Closes #17 (OpenResponses fail-open: unverified tools auto-approved)
- Related: #16 (Meta audit tracker)

---

## Audit References

| Finding | Location | Issue |
|---|---|---|
| S-01 | `handle_tool_call()` L214-224 | Fail-open default |
| S-02 | `_verify_*()` L228-379 | Hardcoded `verified=True` |
| S-06 | `_verify_aml()` L307 | 5 vs 14 country mismatch |
| S-04 | `_verify_npv()` L239 | `float(npv)` precision leak |

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Security Improvements**
  * Tools without registered verification functions are now rejected by default instead of approved, improving fail-closed security posture.

* **New Features**
  * Introduced status distinction between computed calculations and verified results with structured metadata.
  * API responses now include explicit verification status and transparency about whether outcomes are computed or verified.

* **Tests**
  * Added comprehensive test coverage for verification behavior and tool rejection scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->