### PR TITLE
fix(guards): migrate BondGuard, DerivativesGuard, RiskGuard from float to Decimal/mpmath

### DIFF
--- a/qwed_finance/bond_guard.py
+++ b/qwed_finance/bond_guard.py
@@ -83,8 +83,7 @@ class BondGuard:
             BondResult with verification status
         """
         # Parse LLM's YTM
-        llm_rate = self._parse_rate(llm_ytm)
-        llm_rate_d = Decimal(str(llm_rate))
+        llm_rate_d = self._parse_rate(llm_ytm)
         
         # Convert inputs to Decimal at the boundary
         fv = Decimal(str(face_value))
@@ -363,9 +362,9 @@ class BondGuard:
         
         return BondResult(
             verified=verified,
-            llm_value=f"${llm_val:.2f}",
-            computed_value=f"${computed:.2f}",
-            difference=f"${diff:.2f}" if not verified else None,
+            llm_value=f"${llm_val.quantize(Decimal('0.01'), rounding=ROUND_HALF_UP)}",
+            computed_value=f"${computed.quantize(Decimal('0.01'), rounding=ROUND_HALF_UP)}",
+            difference=f"${diff.quantize(Decimal('0.01'), rounding=ROUND_HALF_UP)}" if not verified else None,
             formula_used="Accrued = (Days/Period) × Coupon"
         )
     
@@ -397,28 +396,28 @@ class BondGuard:
         
         return BondResult(
             verified=verified,
-            llm_value=f"${llm_val:.2f}",
-            computed_value=f"${computed:.2f}",
-            difference=f"${diff:.2f}" if not verified else None,
+            llm_value=f"${llm_val.quantize(Decimal('0.01'), rounding=ROUND_HALF_UP)}",
+            computed_value=f"${computed.quantize(Decimal('0.01'), rounding=ROUND_HALF_UP)}",
+            difference=f"${diff.quantize(Decimal('0.01'), rounding=ROUND_HALF_UP)}" if not verified else None,
             formula_used="Dirty Price = Clean Price + Accrued Interest"
         )
     
-    def _parse_rate(self, rate_str: str) -> float:
-        """Parse rate string to float — fail-closed, no silent guessing.
+    def _parse_rate(self, rate_str: str) -> Decimal:
+        """Parse rate string to Decimal — fail-closed, no silent guessing.
 
         Rules:
-          - "5.25%" or "5.25 %" → 0.0525  (explicit percentage)
-          - "0.0525"            → 0.0525  (explicit decimal fraction)
-          - "5.25" (no %)       → 5.25    (no guessing; caller must include '%' for percent format)
+          - "5.25%" or "5.25 %" → Decimal("0.0525")  (explicit percentage)
+          - "0.0525"            → Decimal("0.0525")  (explicit decimal fraction)
+          - "5.25" (no %)       → Decimal("5.25")    (no guessing; caller must include '%' for percent format)
 
         QWED philosophy: if format is ambiguous, do NOT guess.
         Callers must use explicit '%' suffix for percentage values.
         """
         rate_str = rate_str.strip()
         if "%" in rate_str:
-            return float(rate_str.replace("%", "").strip()) / 100
+            return Decimal(rate_str.replace("%", "").strip()) / Decimal("100")
         # No % symbol: treat as decimal fraction (0.05 means 5%)
-        return float(rate_str)
+        return Decimal(rate_str)
     
     def _parse_money(self, value: str) -> Decimal:
         """Parse money string to Decimal"""

--- a/qwed_finance/bond_guard.py
+++ b/qwed_finance/bond_guard.py
@@ -1,13 +1,17 @@
 """
 Bond Guard - Fixed income verification for bond pricing
 Deterministic verification for YTM, Duration, Convexity calculations
+
+All financial math uses Decimal for exact arithmetic.
 """
 
 from dataclasses import dataclass
-from decimal import Decimal, ROUND_HALF_UP
+from decimal import Decimal, ROUND_HALF_UP, getcontext
 from typing import List, Optional, Tuple
 from enum import Enum
-import math
+
+# Set precision high enough for Newton-Raphson convergence
+getcontext().prec = 50
 
 
 class DayCountConvention(Enum):
@@ -33,7 +37,10 @@ class BondResult:
 class BondGuard:
     """
     Deterministic verification for bond calculations.
-    Uses Newton-Raphson for YTM solving - 100% deterministic.
+    Uses Newton-Raphson for YTM solving — 100% deterministic.
+
+    All internal math uses Decimal for exact arithmetic,
+    following the TradingGuard gold standard.
     """
     
     def __init__(self, tolerance_pct: float = 0.5, max_iterations: int = 100):
@@ -44,7 +51,7 @@ class BondGuard:
             tolerance_pct: Acceptable % difference for verification
             max_iterations: Max iterations for YTM solver
         """
-        self.tolerance_pct = tolerance_pct
+        self.tolerance_pct = Decimal(str(tolerance_pct))
         self.max_iterations = max_iterations
     
     def verify_ytm(
@@ -77,30 +84,44 @@ class BondGuard:
         """
         # Parse LLM's YTM
         llm_rate = self._parse_rate(llm_ytm)
+        llm_rate_d = Decimal(str(llm_rate))
+        
+        # Convert inputs to Decimal at the boundary
+        fv = Decimal(str(face_value))
+        cr = Decimal(str(coupon_rate))
+        p = Decimal(str(price))
+        freq = Decimal(str(frequency))
         
         # Calculate periodic values
         n_periods = int(years_to_maturity * frequency)
-        coupon_payment = (face_value * coupon_rate) / frequency
+        coupon_payment = (fv * cr) / freq
         
         # Newton-Raphson to find YTM
         computed_ytm = self._solve_ytm(
-            face_value, coupon_payment, price, n_periods, frequency
+            fv, coupon_payment, p, n_periods, frequency
         )
         
         # Compare
-        diff_pct = abs(computed_ytm - llm_rate) / computed_ytm * 100 if computed_ytm > 0 else 0
+        if computed_ytm > 0:
+            diff_pct = abs(computed_ytm - llm_rate_d) / computed_ytm * 100
+        else:
+            diff_pct = Decimal("0")
         verified = diff_pct <= self.tolerance_pct
+        
+        # Format output with quantized precision
+        computed_pct = (computed_ytm * 100).quantize(Decimal("0.0001"), rounding=ROUND_HALF_UP)
+        llm_pct = (llm_rate_d * 100).quantize(Decimal("0.0001"), rounding=ROUND_HALF_UP)
         
         return BondResult(
             verified=verified,
-            llm_value=f"{llm_rate * 100:.4f}%",
-            computed_value=f"{computed_ytm * 100:.4f}%",
-            difference=f"{diff_pct:.4f}%" if not verified else None,
+            llm_value=f"{llm_pct}%",
+            computed_value=f"{computed_pct}%",
+            difference=f"{diff_pct.quantize(Decimal('0.0001'), rounding=ROUND_HALF_UP)}%" if not verified else None,
             formula_used="Newton-Raphson YTM Solver",
             details={
-                "face_value": face_value,
-                "coupon_rate": f"{coupon_rate * 100}%",
-                "price": price,
+                "face_value": str(fv),
+                "coupon_rate": f"{cr * 100}%",
+                "price": str(p),
                 "periods": n_periods,
                 "frequency": frequency
             }
@@ -108,43 +129,44 @@ class BondGuard:
     
     def _solve_ytm(
         self,
-        face_value: float,
-        coupon: float,
-        price: float,
+        face_value: Decimal,
+        coupon: Decimal,
+        price: Decimal,
         n_periods: int,
         frequency: int
-    ) -> float:
-        """Newton-Raphson YTM solver"""
+    ) -> Decimal:
+        """Newton-Raphson YTM solver using Decimal arithmetic."""
+        freq = Decimal(str(frequency))
+        
         # Initial guess (current yield)
-        ytm = (coupon * frequency) / price
+        ytm = (coupon * freq) / price
         
         for _ in range(self.max_iterations):
             # Bond price at current ytm
-            pv_coupons = sum(
-                coupon / ((1 + ytm / frequency) ** t) 
-                for t in range(1, n_periods + 1)
-            )
-            pv_face = face_value / ((1 + ytm / frequency) ** n_periods)
+            pv_coupons = Decimal("0")
+            for t in range(1, n_periods + 1):
+                pv_coupons += coupon / ((1 + ytm / freq) ** t)
+            
+            pv_face = face_value / ((1 + ytm / freq) ** n_periods)
             bond_price = pv_coupons + pv_face
             
             # Derivative (duration-based approximation)
-            dpv = -sum(
-                t * coupon / ((1 + ytm / frequency) ** (t + 1)) / frequency
-                for t in range(1, n_periods + 1)
-            )
-            dpv -= n_periods * face_value / ((1 + ytm / frequency) ** (n_periods + 1)) / frequency
+            dpv = Decimal("0")
+            for t in range(1, n_periods + 1):
+                dpv -= Decimal(str(t)) * coupon / ((1 + ytm / freq) ** (t + 1)) / freq
+            dpv -= Decimal(str(n_periods)) * face_value / ((1 + ytm / freq) ** (n_periods + 1)) / freq
             
             # Newton step
             diff = bond_price - price
-            if abs(diff) < 1e-10:
+            if abs(diff) < Decimal("1E-10"):
                 break
             
-            if abs(dpv) > 1e-10:
+            if abs(dpv) > Decimal("1E-10"):
                 ytm = ytm - diff / dpv
             
             # Keep YTM in a reasonable range for convergence
             # Upper bound 10.0 (1000%) supports distressed debt scenarios
-            ytm = max(0.0001, min(ytm, 10.0))
+            ytm = max(Decimal("0.0001"), min(ytm, Decimal("10")))
         
         return ytm
     
@@ -176,43 +198,54 @@ class BondGuard:
             BondResult with verification status
         """
         # Parse LLM's duration
-        llm_dur = float(llm_duration.replace("years", "").replace("yrs", "").strip())
+        llm_dur = Decimal(llm_duration.replace("years", "").replace("yrs", "").strip())
+        
+        # Convert to Decimal
+        fv = Decimal(str(face_value))
+        cr = Decimal(str(coupon_rate))
+        y = Decimal(str(ytm))
+        freq = Decimal(str(frequency))
         
         # Calculate duration
         n_periods = int(years_to_maturity * frequency)
-        coupon_payment = (face_value * coupon_rate) / frequency
-        periodic_rate = ytm / frequency
+        coupon_payment = (fv * cr) / freq
+        periodic_rate = y / freq
         
         # Calculate price and weighted time
-        weighted_time = 0
-        price = 0
+        weighted_time = Decimal("0")
+        price = Decimal("0")
         
         for t in range(1, n_periods + 1):
             pv = coupon_payment / ((1 + periodic_rate) ** t)
             price += pv
-            weighted_time += (t / frequency) * pv
+            weighted_time += (Decimal(str(t)) / freq) * pv
         
         # Add face value
-        pv_face = face_value / ((1 + periodic_rate) ** n_periods)
+        pv_face = fv / ((1 + periodic_rate) ** n_periods)
         price += pv_face
-        weighted_time += years_to_maturity * pv_face
+        weighted_time += Decimal(str(years_to_maturity)) * pv_face
         
         # Macaulay duration
         computed_duration = weighted_time / price
+        computed_dur_q = computed_duration.quantize(Decimal("0.0001"), rounding=ROUND_HALF_UP)
         
         # Compare
-        diff = abs(computed_duration - llm_dur)
-        verified = diff <= 0.05  # Within 0.05 years tolerance
+        diff = abs(computed_dur_q - llm_dur)
+        verified = diff <= Decimal("0.05")  # Within 0.05 years tolerance
+        
+        # Modified duration
+        mod_duration = computed_duration / (1 + periodic_rate)
+        mod_dur_q = mod_duration.quantize(Decimal("0.0001"), rounding=ROUND_HALF_UP)
         
         return BondResult(
             verified=verified,
-            llm_value=f"{llm_dur:.4f} years",
-            computed_value=f"{computed_duration:.4f} years",
-            difference=f"{diff:.4f} years" if not verified else None,
+            llm_value=f"{llm_dur} years",
+            computed_value=f"{computed_dur_q} years",
+            difference=f"{diff.quantize(Decimal('0.0001'), rounding=ROUND_HALF_UP)} years" if not verified else None,
             formula_used="Macaulay Duration = Σ(t × PV(CFt)) / Price",
             details={
-                "price": f"${price:.2f}",
-                "modified_duration": f"{computed_duration / (1 + periodic_rate):.4f} years"
+                "price": f"${price.quantize(Decimal('0.01'), rounding=ROUND_HALF_UP)}",
+                "modified_duration": f"{mod_dur_q} years"
             }
         )
     
@@ -244,38 +277,50 @@ class BondGuard:
             BondResult with verification status
         """
         # Parse LLM's convexity
-        llm_conv = float(llm_convexity.replace("years²", "").strip())
+        llm_conv = Decimal(llm_convexity.replace("years²", "").strip())
+        
+        # Convert to Decimal
+        fv = Decimal(str(face_value))
+        cr = Decimal(str(coupon_rate))
+        y = Decimal(str(ytm))
+        freq = Decimal(str(frequency))
         
         # Calculate convexity
         n_periods = int(years_to_maturity * frequency)
-        coupon_payment = (face_value * coupon_rate) / frequency
-        periodic_rate = ytm / frequency
+        coupon_payment = (fv * cr) / freq
+        periodic_rate = y / freq
         
         # Calculate weighted sum and price
-        weighted_sum = 0
-        price = 0
+        weighted_sum = Decimal("0")
+        price = Decimal("0")
         
         for t in range(1, n_periods + 1):
+            td = Decimal(str(t))
             pv = coupon_payment / ((1 + periodic_rate) ** t)
             price += pv
-            weighted_sum += t * (t + 1) * pv
+            weighted_sum += td * (td + 1) * pv
         
-        pv_face = face_value / ((1 + periodic_rate) ** n_periods)
+        pv_face = fv / ((1 + periodic_rate) ** n_periods)
         price += pv_face
-        weighted_sum += n_periods * (n_periods + 1) * pv_face
+        nd = Decimal(str(n_periods))
+        weighted_sum += nd * (nd + 1) * pv_face
         
         # Convexity in years
-        computed_convexity = weighted_sum / (price * ((1 + periodic_rate) ** 2) * (frequency ** 2))
+        computed_convexity = weighted_sum / (price * ((1 + periodic_rate) ** 2) * (freq ** 2))
+        computed_conv_q = computed_convexity.quantize(Decimal("0.0001"), rounding=ROUND_HALF_UP)
         
         # Compare
-        diff_pct = abs(computed_convexity - llm_conv) / computed_convexity * 100 if computed_convexity > 0 else 0
+        if computed_convexity > 0:
+            diff_pct = abs(computed_convexity - llm_conv) / computed_convexity * 100
+        else:
+            diff_pct = Decimal("0")
         verified = diff_pct <= self.tolerance_pct
         
         return BondResult(
             verified=verified,
-            llm_value=f"{llm_conv:.4f}",
-            computed_value=f"{computed_convexity:.4f}",
-            difference=f"{diff_pct:.2f}%" if not verified else None,
+            llm_value=f"{llm_conv}",
+            computed_value=f"{computed_conv_q}",
+            difference=f"{diff_pct.quantize(Decimal('0.01'), rounding=ROUND_HALF_UP)}%" if not verified else None,
             formula_used="Convexity = Σ(t(t+1) × PV(CFt)) / (P × (1+y)²)"
         )
     

--- a/qwed_finance/derivatives_guard.py
+++ b/qwed_finance/derivatives_guard.py
@@ -154,7 +154,7 @@ class DerivativesGuard:
     
     def _calculate_greeks(
         self,
-        S, K, T, r, sigma,
+        spot, strike, time_exp, rate, sigma,
         option_type: OptionType,
         d1, d2
     ) -> dict:
@@ -163,7 +163,7 @@ class DerivativesGuard:
         
         All computed using mpmath for precision, then quantized to Decimal for output.
         """
-        sqrt_T = mpmath.sqrt(T)
+        sqrt_time = mpmath.sqrt(time_exp)
         
         # Delta: ∂V/∂S
         if option_type == OptionType.CALL:
@@ -172,25 +172,25 @@ class DerivativesGuard:
             delta = self._norm_cdf(d1) - 1
         
         # Gamma: ∂²V/∂S²
-        gamma = self._norm_pdf(d1) / (S * sigma * sqrt_T)
+        gamma = self._norm_pdf(d1) / (spot * sigma * sqrt_time)
         
         # Theta: ∂V/∂T (per day, so divide by 365)
-        theta_base = -(S * self._norm_pdf(d1) * sigma) / (2 * sqrt_T)
+        theta_base = -(spot * self._norm_pdf(d1) * sigma) / (2 * sqrt_time)
         if option_type == OptionType.CALL:
-            theta = theta_base - r * K * mpmath.exp(-r * T) * self._norm_cdf(d2)
+            theta = theta_base - rate * strike * mpmath.exp(-rate * time_exp) * self._norm_cdf(d2)
         else:
-            theta = theta_base + r * K * mpmath.exp(-r * T) * self._norm_cdf(-d2)
+            theta = theta_base + rate * strike * mpmath.exp(-rate * time_exp) * self._norm_cdf(-d2)
         theta_daily = theta / 365
         
         # Vega: ∂V/∂σ (per 1% move, so divide by 100)
-        vega = S * sqrt_T * self._norm_pdf(d1)
+        vega = spot * sqrt_time * self._norm_pdf(d1)
         vega_pct = vega / 100
         
         # Rho: ∂V/∂r (per 1% move, so divide by 100)
         if option_type == OptionType.CALL:
-            rho = K * T * mpmath.exp(-r * T) * self._norm_cdf(d2)
+            rho = strike * time_exp * mpmath.exp(-rate * time_exp) * self._norm_cdf(d2)
         else:
-            rho = -K * T * mpmath.exp(-r * T) * self._norm_cdf(-d2)
+            rho = -strike * time_exp * mpmath.exp(-rate * time_exp) * self._norm_cdf(-d2)
         rho_pct = rho / 100
         
         # Quantize output via Decimal for exact representation

--- a/qwed_finance/derivatives_guard.py
+++ b/qwed_finance/derivatives_guard.py
@@ -1,13 +1,20 @@
 """
 Derivatives Guard - Black-Scholes options pricing and margin verification
 Deterministic verification for derivatives trading
+
+Uses mpmath for arbitrary-precision transcendental functions (log, exp, sqrt, erf).
+All monetary outputs use Decimal for exact representation.
 """
 
 from dataclasses import dataclass
-from decimal import Decimal, ROUND_HALF_UP
+from decimal import Decimal, ROUND_HALF_UP, getcontext
 from typing import Optional, Tuple
 from enum import Enum
-import math
+import mpmath
+
+# Set precision for both Decimal and mpmath
+getcontext().prec = 50
+mpmath.mp.dps = 30  # 30 decimal places for mpmath
 
 
 class OptionType(Enum):
@@ -30,7 +37,10 @@ class DerivativesResult:
 class DerivativesGuard:
     """
     Deterministic verification for derivatives pricing.
-    Uses Black-Scholes formula (pure calculus) for options verification.
+    Uses Black-Scholes formula with mpmath for arbitrary-precision
+    transcendental functions (log, exp, sqrt, erf).
+
+    All monetary outputs are quantized via Decimal for exact representation.
     """
     
     def __init__(self, tolerance_pct: float = 1.0):
@@ -40,7 +50,7 @@ class DerivativesGuard:
         Args:
             tolerance_pct: Acceptable % difference for price verification
         """
-        self.tolerance_pct = tolerance_pct
+        self.tolerance_pct = Decimal(str(tolerance_pct))
         self._sympy_available = self._check_sympy()
     
     def _check_sympy(self) -> bool:
@@ -73,6 +83,8 @@ class DerivativesGuard:
         d1 = (ln(S/K) + (r + σ²/2)*T) / (σ*√T)
         d2 = d1 - σ*√T
         
+        Uses mpmath for arbitrary-precision transcendental functions.
+        
         Args:
             spot_price: Current price of underlying (S)
             strike_price: Strike price (K)
@@ -85,21 +97,22 @@ class DerivativesGuard:
         Returns:
             DerivativesResult with verification
         """
-        S = spot_price
-        K = strike_price
-        T = time_to_expiry
-        r = risk_free_rate
-        sigma = volatility
+        # Use mpmath for high-precision transcendental math
+        S = mpmath.mpf(str(spot_price))
+        K = mpmath.mpf(str(strike_price))
+        T = mpmath.mpf(str(time_to_expiry))
+        r = mpmath.mpf(str(risk_free_rate))
+        sigma = mpmath.mpf(str(volatility))
         
         # Calculate d1 and d2
-        d1 = (math.log(S / K) + (r + (sigma ** 2) / 2) * T) / (sigma * math.sqrt(T))
-        d2 = d1 - sigma * math.sqrt(T)
+        d1 = (mpmath.log(S / K) + (r + (sigma ** 2) / 2) * T) / (sigma * mpmath.sqrt(T))
+        d2 = d1 - sigma * mpmath.sqrt(T)
         
         # Calculate option price
         if option_type == OptionType.CALL:
-            price = S * self._norm_cdf(d1) - K * math.exp(-r * T) * self._norm_cdf(d2)
+            price = S * self._norm_cdf(d1) - K * mpmath.exp(-r * T) * self._norm_cdf(d2)
         else:  # PUT
-            price = K * math.exp(-r * T) * self._norm_cdf(-d2) - S * self._norm_cdf(-d1)
+            price = K * mpmath.exp(-r * T) * self._norm_cdf(-d2) - S * self._norm_cdf(-d1)
         
         # Calculate Greeks
         greeks = self._calculate_greeks(S, K, T, r, sigma, option_type, d1, d2)
@@ -107,48 +120,50 @@ class DerivativesGuard:
         # Parse LLM price
         import re
         llm_clean = re.sub(r'[$,\s]', '', llm_price)
-        llm_decimal = float(llm_clean)
+        llm_decimal = Decimal(llm_clean)
+        
+        # Convert price to Decimal for comparison
+        price_d = Decimal(str(mpmath.nstr(price, 15)))
+        price_q = price_d.quantize(Decimal("0.01"), rounding=ROUND_HALF_UP)
         
         # Compare
-        difference = abs(llm_decimal - price)
-        difference_pct = (difference / price) * 100 if price > 0 else 0
+        difference = abs(llm_decimal - price_d)
+        if price_d > 0:
+            difference_pct = (difference / price_d) * 100
+        else:
+            difference_pct = Decimal("0")
         
         verified = difference_pct <= self.tolerance_pct
         
         return DerivativesResult(
             verified=verified,
             llm_price=llm_price,
-            computed_price=f"${price:.2f}",
-            difference=f"${difference:.2f} ({difference_pct:.2f}%)" if not verified else None,
+            computed_price=f"${price_q}",
+            difference=f"${difference.quantize(Decimal('0.01'), rounding=ROUND_HALF_UP)} ({difference_pct.quantize(Decimal('0.01'), rounding=ROUND_HALF_UP)}%)" if not verified else None,
             greeks=greeks,
             formula_used="Black-Scholes: C = S·N(d₁) - K·e^(-rT)·N(d₂)"
         )
     
-    def _norm_cdf(self, x: float) -> float:
-        """Standard normal cumulative distribution function"""
-        return 0.5 * (1 + math.erf(x / math.sqrt(2)))
+    def _norm_cdf(self, x) -> mpmath.mpf:
+        """Standard normal cumulative distribution function using mpmath."""
+        return mpmath.mpf("0.5") * (1 + mpmath.erf(x / mpmath.sqrt(2)))
     
-    def _norm_pdf(self, x: float) -> float:
-        """Standard normal probability density function"""
-        return math.exp(-0.5 * x ** 2) / math.sqrt(2 * math.pi)
+    def _norm_pdf(self, x) -> mpmath.mpf:
+        """Standard normal probability density function using mpmath."""
+        return mpmath.exp(mpmath.mpf("-0.5") * x ** 2) / mpmath.sqrt(2 * mpmath.pi)
     
     def _calculate_greeks(
         self,
-        S: float,
-        K: float,
-        T: float,
-        r: float,
-        sigma: float,
+        S, K, T, r, sigma,
         option_type: OptionType,
-        d1: float,
-        d2: float
+        d1, d2
     ) -> dict:
         """
         Calculate option Greeks (risk sensitivities).
         
-        All are pure calculus - 100% deterministic.
+        All computed using mpmath for precision, then quantized to Decimal for output.
         """
-        sqrt_T = math.sqrt(T)
+        sqrt_T = mpmath.sqrt(T)
         
         # Delta: ∂V/∂S
         if option_type == OptionType.CALL:
@@ -162,9 +177,9 @@ class DerivativesGuard:
         # Theta: ∂V/∂T (per day, so divide by 365)
         theta_base = -(S * self._norm_pdf(d1) * sigma) / (2 * sqrt_T)
         if option_type == OptionType.CALL:
-            theta = theta_base - r * K * math.exp(-r * T) * self._norm_cdf(d2)
+            theta = theta_base - r * K * mpmath.exp(-r * T) * self._norm_cdf(d2)
         else:
-            theta = theta_base + r * K * math.exp(-r * T) * self._norm_cdf(-d2)
+            theta = theta_base + r * K * mpmath.exp(-r * T) * self._norm_cdf(-d2)
         theta_daily = theta / 365
         
         # Vega: ∂V/∂σ (per 1% move, so divide by 100)
@@ -173,17 +188,21 @@ class DerivativesGuard:
         
         # Rho: ∂V/∂r (per 1% move, so divide by 100)
         if option_type == OptionType.CALL:
-            rho = K * T * math.exp(-r * T) * self._norm_cdf(d2)
+            rho = K * T * mpmath.exp(-r * T) * self._norm_cdf(d2)
         else:
-            rho = -K * T * math.exp(-r * T) * self._norm_cdf(-d2)
+            rho = -K * T * mpmath.exp(-r * T) * self._norm_cdf(-d2)
         rho_pct = rho / 100
         
+        # Quantize output via Decimal for exact representation
+        def to_dec(val, places):
+            return str(Decimal(str(mpmath.nstr(val, 15))).quantize(Decimal(places), rounding=ROUND_HALF_UP))
+        
         return {
-            "delta": round(delta, 4),
-            "gamma": round(gamma, 6),
-            "theta": round(theta_daily, 4),    # Per day
-            "vega": round(vega_pct, 4),        # Per 1% vol move
-            "rho": round(rho_pct, 4)           # Per 1% rate move
+            "delta": to_dec(delta, "0.0001"),
+            "gamma": to_dec(gamma, "0.000001"),
+            "theta": to_dec(theta_daily, "0.0001"),    # Per day
+            "vega": to_dec(vega_pct, "0.0001"),        # Per 1% vol move
+            "rho": to_dec(rho_pct, "0.0001")           # Per 1% rate move
         }
     
     def verify_delta(
@@ -202,23 +221,32 @@ class DerivativesGuard:
         
         Delta = ∂V/∂S = N(d₁) for calls, N(d₁)-1 for puts
         """
-        S, K, T, r, sigma = spot_price, strike_price, time_to_expiry, risk_free_rate, volatility
+        S = mpmath.mpf(str(spot_price))
+        K = mpmath.mpf(str(strike_price))
+        T = mpmath.mpf(str(time_to_expiry))
+        r = mpmath.mpf(str(risk_free_rate))
+        sigma = mpmath.mpf(str(volatility))
         
-        d1 = (math.log(S / K) + (r + (sigma ** 2) / 2) * T) / (sigma * math.sqrt(T))
+        d1 = (mpmath.log(S / K) + (r + (sigma ** 2) / 2) * T) / (sigma * mpmath.sqrt(T))
         
         if option_type == OptionType.CALL:
             computed_delta = self._norm_cdf(d1)
         else:
             computed_delta = self._norm_cdf(d1) - 1
         
-        difference = abs(llm_delta - computed_delta)
-        verified = difference <= tolerance
+        # Convert to Decimal for comparison
+        computed_d = Decimal(str(mpmath.nstr(computed_delta, 15)))
+        llm_d = Decimal(str(llm_delta))
+        tol_d = Decimal(str(tolerance))
+        
+        difference = abs(llm_d - computed_d)
+        verified = difference <= tol_d
         
         return DerivativesResult(
             verified=verified,
             llm_price=str(llm_delta),
-            computed_price=f"{computed_delta:.4f}",
-            difference=f"{difference:.4f}" if not verified else None,
+            computed_price=f"{computed_d.quantize(Decimal('0.0001'), rounding=ROUND_HALF_UP)}",
+            difference=f"{difference.quantize(Decimal('0.0001'), rounding=ROUND_HALF_UP)}" if not verified else None,
             formula_used="Delta = N(d₁) for calls"
         )
     
@@ -245,8 +273,13 @@ class DerivativesGuard:
         Returns:
             DerivativesResult
         """
-        required_margin = maintenance_margin * position_value
-        should_margin_call = account_equity < required_margin
+        # Use Decimal for exact comparison
+        equity_d = Decimal(str(account_equity))
+        maint_d = Decimal(str(maintenance_margin))
+        pos_d = Decimal(str(position_value))
+        
+        required_margin = maint_d * pos_d
+        should_margin_call = equity_d < required_margin
         
         verified = (llm_margin_call == should_margin_call)
         
@@ -254,7 +287,7 @@ class DerivativesGuard:
             verified=verified,
             llm_price="MARGIN_CALL" if llm_margin_call else "NO_CALL",
             computed_price="MARGIN_CALL" if should_margin_call else "NO_CALL",
-            margin_status=f"Equity: ${account_equity:.2f}, Required: ${required_margin:.2f}",
+            margin_status=f"Equity: ${equity_d.quantize(Decimal('0.01'), rounding=ROUND_HALF_UP)}, Required: ${required_margin.quantize(Decimal('0.01'), rounding=ROUND_HALF_UP)}",
             formula_used="Margin Call if Equity < MaintenanceReq × PositionValue"
         )
     
@@ -312,6 +345,8 @@ class DerivativesGuard:
         
         C - P = S - K*e^(-rT)
         
+        Uses mpmath for exp() to avoid float precision loss.
+        
         Args:
             call_price: Market call price
             put_price: Market put price
@@ -324,18 +359,27 @@ class DerivativesGuard:
         Returns:
             DerivativesResult
         """
-        S, K, T, r = spot_price, strike_price, time_to_expiry, risk_free_rate
+        # Use mpmath for exp, then Decimal for comparison
+        S = mpmath.mpf(str(spot_price))
+        K = mpmath.mpf(str(strike_price))
+        T = mpmath.mpf(str(time_to_expiry))
+        r = mpmath.mpf(str(risk_free_rate))
         
-        lhs = call_price - put_price
-        rhs = S - K * math.exp(-r * T)
+        lhs = mpmath.mpf(str(call_price)) - mpmath.mpf(str(put_price))
+        rhs = S - K * mpmath.exp(-r * T)
         
-        difference = abs(lhs - rhs)
-        verified = difference <= tolerance
+        # Convert to Decimal for exact comparison
+        lhs_d = Decimal(str(mpmath.nstr(lhs, 15)))
+        rhs_d = Decimal(str(mpmath.nstr(rhs, 15)))
+        tol_d = Decimal(str(tolerance))
+        
+        difference = abs(lhs_d - rhs_d)
+        verified = difference <= tol_d
         
         return DerivativesResult(
             verified=verified,
-            llm_price=f"C-P = {lhs:.2f}",
-            computed_price=f"S-Ke^(-rT) = {rhs:.2f}",
-            difference=f"{difference:.2f}" if not verified else None,
+            llm_price=f"C-P = {lhs_d.quantize(Decimal('0.01'), rounding=ROUND_HALF_UP)}",
+            computed_price=f"S-Ke^(-rT) = {rhs_d.quantize(Decimal('0.01'), rounding=ROUND_HALF_UP)}",
+            difference=f"{difference.quantize(Decimal('0.01'), rounding=ROUND_HALF_UP)}" if not verified else None,
             formula_used="Put-Call Parity: C - P = S - K·e^(-rT)"
         )

--- a/qwed_finance/risk_guard.py
+++ b/qwed_finance/risk_guard.py
@@ -1,13 +1,17 @@
 """
 Risk Guard - Portfolio risk metrics verification
 Deterministic verification for VaR, Beta, Sharpe, and other risk measures
+
+All financial math uses Decimal for exact arithmetic.
 """
 
 from dataclasses import dataclass
-from decimal import Decimal, ROUND_HALF_UP
+from decimal import Decimal, ROUND_HALF_UP, getcontext
 from typing import List, Optional, Tuple
 from enum import Enum
-import math
+
+# Set precision high enough for statistical calculations
+getcontext().prec = 50
 
 
 class VaRMethod(Enum):
@@ -24,11 +28,11 @@ class ConfidenceLevel(Enum):
     NINETY_NINE = 0.99
 
 
-# Z-scores for standard confidence levels
+# Z-scores for standard confidence levels (stored as Decimal strings)
 Z_SCORES = {
-    0.90: 1.282,
-    0.95: 1.645,
-    0.99: 2.326
+    0.90: Decimal("1.282"),
+    0.95: Decimal("1.645"),
+    0.99: Decimal("2.326")
 }
 
 
@@ -47,7 +51,10 @@ class RiskResult:
 class RiskGuard:
     """
     Deterministic verification for portfolio risk metrics.
-    Uses parametric methods for VaR - 100% deterministic.
+    Uses parametric methods for VaR — 100% deterministic.
+
+    All internal math uses Decimal for exact arithmetic,
+    following the TradingGuard gold standard.
     """
     
     def __init__(self, tolerance_pct: float = 1.0):
@@ -57,7 +64,7 @@ class RiskGuard:
         Args:
             tolerance_pct: Acceptable % difference for verification
         """
-        self.tolerance_pct = tolerance_pct
+        self.tolerance_pct = Decimal(str(tolerance_pct))
     
     def verify_var(
         self,
@@ -92,26 +99,33 @@ class RiskGuard:
         # Get z-score (interpolate if not standard)
         z_score = Z_SCORES.get(confidence_level, self._interpolate_z(confidence_level))
         
-        # Parametric VaR formula
-        var = Decimal(str(portfolio_value)) * Decimal(str(daily_volatility)) * Decimal(str(z_score)) * Decimal(str(math.sqrt(holding_period_days)))
+        # Parametric VaR formula — fully Decimal
+        # Use Decimal.sqrt() instead of math.sqrt() to avoid float leak
+        holding_d = Decimal(str(holding_period_days))
+        sqrt_holding = holding_d.sqrt()
+        
+        var = Decimal(str(portfolio_value)) * Decimal(str(daily_volatility)) * z_score * sqrt_holding
         computed_var = var.quantize(Decimal("0.01"), rounding=ROUND_HALF_UP)
         
         # Compare
-        diff_pct = abs(computed_var - llm_val) / computed_var * 100 if computed_var > 0 else 0
-        verified = float(diff_pct) <= self.tolerance_pct
+        if computed_var > 0:
+            diff_pct = abs(computed_var - llm_val) / computed_var * 100
+        else:
+            diff_pct = Decimal("0")
+        verified = diff_pct <= self.tolerance_pct
         
         return RiskResult(
             verified=verified,
             llm_value=f"${llm_val:,.2f}",
             computed_value=f"${computed_var:,.2f}",
-            difference=f"{diff_pct:.2f}%" if not verified else None,
+            difference=f"{diff_pct.quantize(Decimal('0.01'), rounding=ROUND_HALF_UP)}%" if not verified else None,
             formula_used="VaR = P × σ × z × √t",
             details={
-                "portfolio_value": f"${portfolio_value:,.0f}",
-                "daily_volatility": f"{daily_volatility * 100:.2f}%",
-                "z_score": z_score,
+                "portfolio_value": f"${Decimal(str(portfolio_value)):,.0f}",
+                "daily_volatility": f"{Decimal(str(daily_volatility)) * 100}%",
+                "z_score": str(z_score),
                 "holding_period": f"{holding_period_days} days",
-                "confidence": f"{confidence_level * 100:.0f}%"
+                "confidence": f"{Decimal(str(confidence_level)) * 100}%"
             }
         )
     
@@ -127,6 +141,8 @@ class RiskGuard:
         β = Cov(r_asset, r_market) / Var(r_market)
         
         Beta measures systematic risk relative to the market.
+        Uses Decimal to prevent catastrophic cancellation when
+        returns are close to their mean.
         
         Args:
             asset_returns: List of asset returns
@@ -136,7 +152,7 @@ class RiskGuard:
         Returns:
             RiskResult with verification status
         """
-        llm_val = float(llm_beta.strip())
+        llm_val = Decimal(llm_beta.strip())
         
         if len(asset_returns) != len(market_returns):
             return RiskResult(
@@ -149,39 +165,48 @@ class RiskGuard:
         
         n = len(asset_returns)
         
-        # Calculate means
-        mean_asset = sum(asset_returns) / n
-        mean_market = sum(market_returns) / n
+        # Convert to Decimal for exact accumulation
+        asset_d = [Decimal(str(r)) for r in asset_returns]
+        market_d = [Decimal(str(r)) for r in market_returns]
+        n_d = Decimal(str(n))
         
-        # Calculate covariance and variance
+        # Calculate means
+        mean_asset = sum(asset_d) / n_d
+        mean_market = sum(market_d) / n_d
+        
+        # Calculate covariance and variance using Decimal
+        # This prevents catastrophic cancellation when returns ≈ mean
         covariance = sum(
-            (asset_returns[i] - mean_asset) * (market_returns[i] - mean_market)
+            (asset_d[i] - mean_asset) * (market_d[i] - mean_market)
             for i in range(n)
-        ) / (n - 1)
+        ) / (n_d - 1)
         
         variance_market = sum(
-            (market_returns[i] - mean_market) ** 2
+            (market_d[i] - mean_market) ** 2
             for i in range(n)
-        ) / (n - 1)
+        ) / (n_d - 1)
         
         # Beta
-        computed_beta = covariance / variance_market if variance_market > 0 else 0
-        computed_beta = round(computed_beta, 4)
+        if variance_market > 0:
+            computed_beta = covariance / variance_market
+        else:
+            computed_beta = Decimal("0")
+        computed_beta_q = computed_beta.quantize(Decimal("0.0001"), rounding=ROUND_HALF_UP)
         
         # Compare
-        diff = abs(computed_beta - llm_val)
-        verified = diff <= 0.05  # Within 0.05 tolerance
+        diff = abs(computed_beta_q - llm_val)
+        verified = diff <= Decimal("0.05")  # Within 0.05 tolerance
         
         return RiskResult(
             verified=verified,
-            llm_value=f"{llm_val:.4f}",
-            computed_value=f"{computed_beta:.4f}",
-            difference=f"{diff:.4f}" if not verified else None,
+            llm_value=f"{llm_val}",
+            computed_value=f"{computed_beta_q}",
+            difference=f"{diff.quantize(Decimal('0.0001'), rounding=ROUND_HALF_UP)}" if not verified else None,
             formula_used="β = Cov(Ra, Rm) / Var(Rm)",
             details={
                 "observations": n,
-                "covariance": f"{covariance:.6f}",
-                "market_variance": f"{variance_market:.6f}"
+                "covariance": str(covariance.quantize(Decimal("0.000001"), rounding=ROUND_HALF_UP)),
+                "market_variance": str(variance_market.quantize(Decimal("0.000001"), rounding=ROUND_HALF_UP))
             }
         )
     
@@ -208,28 +233,36 @@ class RiskGuard:
         Returns:
             RiskResult with verification status
         """
-        llm_val = float(llm_sharpe.strip())
+        llm_val = Decimal(llm_sharpe.strip())
+        
+        # Convert to Decimal
+        rp = Decimal(str(portfolio_return))
+        rf = Decimal(str(risk_free_rate))
+        vol = Decimal(str(portfolio_volatility))
         
         # Sharpe ratio
-        excess_return = portfolio_return - risk_free_rate
-        computed_sharpe = excess_return / portfolio_volatility if portfolio_volatility > 0 else 0
-        computed_sharpe = round(computed_sharpe, 4)
+        excess_return = rp - rf
+        if vol > 0:
+            computed_sharpe = excess_return / vol
+        else:
+            computed_sharpe = Decimal("0")
+        computed_sharpe_q = computed_sharpe.quantize(Decimal("0.0001"), rounding=ROUND_HALF_UP)
         
         # Compare
-        diff = abs(computed_sharpe - llm_val)
-        verified = diff <= 0.05  # Within 0.05 tolerance
+        diff = abs(computed_sharpe_q - llm_val)
+        verified = diff <= Decimal("0.05")  # Within 0.05 tolerance
         
         return RiskResult(
             verified=verified,
-            llm_value=f"{llm_val:.4f}",
-            computed_value=f"{computed_sharpe:.4f}",
-            difference=f"{diff:.4f}" if not verified else None,
+            llm_value=f"{llm_val}",
+            computed_value=f"{computed_sharpe_q}",
+            difference=f"{diff.quantize(Decimal('0.0001'), rounding=ROUND_HALF_UP)}" if not verified else None,
             formula_used="Sharpe = (Rp - Rf) / σp",
             details={
-                "portfolio_return": f"{portfolio_return * 100:.2f}%",
-                "risk_free_rate": f"{risk_free_rate * 100:.2f}%",
-                "excess_return": f"{excess_return * 100:.2f}%",
-                "volatility": f"{portfolio_volatility * 100:.2f}%"
+                "portfolio_return": f"{rp * 100}%",
+                "risk_free_rate": f"{rf * 100}%",
+                "excess_return": f"{excess_return * 100}%",
+                "volatility": f"{vol * 100}%"
             }
         )
     
@@ -256,7 +289,7 @@ class RiskGuard:
         Returns:
             RiskResult with verification status
         """
-        llm_val = float(llm_sortino.strip())
+        llm_val = Decimal(llm_sortino.strip())
         
         if not downside_returns:
             # No downside returns = infinite Sortino (perfect)
@@ -267,40 +300,50 @@ class RiskGuard:
                 formula_used="Sortino = (Rp - Rt) / σ_downside"
             )
         
-        # Calculate downside deviation
+        # Convert to Decimal
+        rp = Decimal(str(portfolio_return))
+        rt = Decimal(str(target_return))
+        downside_d = [Decimal(str(r)) for r in downside_returns]
         n = len(downside_returns)
+        n_d = Decimal(str(n))
+        
+        # Calculate downside deviation using Decimal
         downside_squared = sum(
-            (r - target_return) ** 2 for r in downside_returns if r < target_return
+            (r - rt) ** 2 for r in downside_d if r < rt
         )
-        downside_deviation = math.sqrt(downside_squared / n) if n > 0 else 0
+        if n > 0 and downside_squared > 0:
+            downside_deviation = (downside_squared / n_d).sqrt()
+        else:
+            downside_deviation = Decimal("0")
         
         # Sortino ratio
-        excess_return = portfolio_return - target_return
-        computed_sortino = excess_return / downside_deviation if downside_deviation > 0 else float('inf')
-        
-        if math.isinf(computed_sortino):
-            verified = llm_val > 10  # High LLM value expected for near-infinite
+        excess_return = rp - rt
+        if downside_deviation > 0:
+            computed_sortino = excess_return / downside_deviation
+        else:
+            # Near-infinite Sortino
+            verified = llm_val > 10  # High LLM value expected
             return RiskResult(
                 verified=verified,
-                llm_value=f"{llm_val:.4f}",
+                llm_value=f"{llm_val}",
                 computed_value="Very High (low downside)",
                 formula_used="Sortino = (Rp - Rt) / σ_downside"
             )
         
-        computed_sortino = round(computed_sortino, 4)
+        computed_sortino_q = computed_sortino.quantize(Decimal("0.0001"), rounding=ROUND_HALF_UP)
         
         # Compare
-        diff = abs(computed_sortino - llm_val)
-        verified = diff <= 0.1  # Within 0.1 tolerance
+        diff = abs(computed_sortino_q - llm_val)
+        verified = diff <= Decimal("0.1")  # Within 0.1 tolerance
         
         return RiskResult(
             verified=verified,
-            llm_value=f"{llm_val:.4f}",
-            computed_value=f"{computed_sortino:.4f}",
-            difference=f"{diff:.4f}" if not verified else None,
+            llm_value=f"{llm_val}",
+            computed_value=f"{computed_sortino_q}",
+            difference=f"{diff.quantize(Decimal('0.0001'), rounding=ROUND_HALF_UP)}" if not verified else None,
             formula_used="Sortino = (Rp - Rt) / σ_downside",
             details={
-                "downside_deviation": f"{downside_deviation * 100:.4f}%",
+                "downside_deviation": f"{(downside_deviation * 100).quantize(Decimal('0.0001'), rounding=ROUND_HALF_UP)}%",
                 "observations_below_target": n
             }
         )
@@ -323,34 +366,37 @@ class RiskGuard:
             RiskResult with verification status
         """
         # Parse LLM's value (handle negative sign)
-        llm_val = abs(float(llm_max_dd.replace("%", "").strip())) / 100
+        llm_val = abs(Decimal(llm_max_dd.replace("%", "").strip())) / 100
         
-        # Calculate max drawdown
-        peak = portfolio_values[0]
-        max_drawdown = 0
+        # Convert to Decimal
+        values_d = [Decimal(str(v)) for v in portfolio_values]
         
-        for value in portfolio_values:
+        # Calculate max drawdown using Decimal
+        peak = values_d[0]
+        max_drawdown = Decimal("0")
+        
+        for value in values_d:
             if value > peak:
                 peak = value
             drawdown = (peak - value) / peak
             if drawdown > max_drawdown:
                 max_drawdown = drawdown
         
-        computed_dd = round(max_drawdown, 6)
+        computed_dd = max_drawdown.quantize(Decimal("0.000001"), rounding=ROUND_HALF_UP)
         
         # Compare
         diff = abs(computed_dd - llm_val)
-        verified = diff <= 0.005  # Within 0.5% tolerance
+        verified = diff <= Decimal("0.005")  # Within 0.5% tolerance
         
         return RiskResult(
             verified=verified,
-            llm_value=f"-{llm_val * 100:.2f}%",
-            computed_value=f"-{computed_dd * 100:.2f}%",
-            difference=f"{diff * 100:.2f}%" if not verified else None,
+            llm_value=f"-{(llm_val * 100).quantize(Decimal('0.01'), rounding=ROUND_HALF_UP)}%",
+            computed_value=f"-{(computed_dd * 100).quantize(Decimal('0.01'), rounding=ROUND_HALF_UP)}%",
+            difference=f"{(diff * 100).quantize(Decimal('0.01'), rounding=ROUND_HALF_UP)}%" if not verified else None,
             formula_used="Max DD = max((Peak - Trough) / Peak)",
             details={
                 "observations": len(portfolio_values),
-                "peak_value": f"${max(portfolio_values):,.2f}"
+                "peak_value": f"${max(values_d):,.2f}"
             }
         )
     
@@ -384,18 +430,24 @@ class RiskGuard:
         computed_es = computed_es.quantize(Decimal("0.01"), rounding=ROUND_HALF_UP)
         
         # Compare
-        diff_pct = abs(computed_es - llm_val) / computed_es * 100 if computed_es > 0 else 0
-        verified = float(diff_pct) <= self.tolerance_pct
+        if computed_es > 0:
+            diff_pct = abs(computed_es - llm_val) / computed_es * 100
+        else:
+            diff_pct = Decimal("0")
+        verified = diff_pct <= self.tolerance_pct
+        
+        var_d = Decimal(str(var_amount))
+        es_to_var = computed_es / var_d if var_d > 0 else Decimal("0")
         
         return RiskResult(
             verified=verified,
             llm_value=f"${llm_val:,.2f}",
             computed_value=f"${computed_es:,.2f}",
-            difference=f"{diff_pct:.2f}%" if not verified else None,
+            difference=f"{diff_pct.quantize(Decimal('0.01'), rounding=ROUND_HALF_UP)}%" if not verified else None,
             formula_used="ES = E[Loss | Loss > VaR]",
             details={
-                "VaR": f"${var_amount:,.2f}",
-                "ES_to_VaR_ratio": f"{float(computed_es) / var_amount:.2f}x" if var_amount > 0 else "N/A"
+                "VaR": f"${var_d:,.2f}",
+                "ES_to_VaR_ratio": f"{es_to_var.quantize(Decimal('0.01'), rounding=ROUND_HALF_UP)}x"
             }
         )
     
@@ -422,38 +474,46 @@ class RiskGuard:
         Returns:
             RiskResult with verification status
         """
-        llm_val = float(llm_ir.strip())
+        llm_val = Decimal(llm_ir.strip())
+        
+        # Convert to Decimal
+        rp = Decimal(str(portfolio_return))
+        rb = Decimal(str(benchmark_return))
+        te = Decimal(str(tracking_error))
         
         # Information ratio
-        active_return = portfolio_return - benchmark_return
-        computed_ir = active_return / tracking_error if tracking_error > 0 else 0
-        computed_ir = round(computed_ir, 4)
+        active_return = rp - rb
+        if te > 0:
+            computed_ir = active_return / te
+        else:
+            computed_ir = Decimal("0")
+        computed_ir_q = computed_ir.quantize(Decimal("0.0001"), rounding=ROUND_HALF_UP)
         
         # Compare
-        diff = abs(computed_ir - llm_val)
-        verified = diff <= 0.05
+        diff = abs(computed_ir_q - llm_val)
+        verified = diff <= Decimal("0.05")
         
         return RiskResult(
             verified=verified,
-            llm_value=f"{llm_val:.4f}",
-            computed_value=f"{computed_ir:.4f}",
-            difference=f"{diff:.4f}" if not verified else None,
+            llm_value=f"{llm_val}",
+            computed_value=f"{computed_ir_q}",
+            difference=f"{diff.quantize(Decimal('0.0001'), rounding=ROUND_HALF_UP)}" if not verified else None,
             formula_used="IR = (Rp - Rb) / TE",
             details={
-                "active_return": f"{active_return * 100:.2f}%",
-                "tracking_error": f"{tracking_error * 100:.2f}%"
+                "active_return": f"{(active_return * 100).quantize(Decimal('0.01'), rounding=ROUND_HALF_UP)}%",
+                "tracking_error": f"{(te * 100).quantize(Decimal('0.01'), rounding=ROUND_HALF_UP)}%"
             }
         )
     
-    def _interpolate_z(self, confidence: float) -> float:
+    def _interpolate_z(self, confidence: float) -> Decimal:
         """Interpolate z-score for non-standard confidence levels"""
-        # Linear interpolation between known z-scores
-        if confidence <= 0.90:
+        c = Decimal(str(confidence))
+        if c <= Decimal("0.90"):
             return Z_SCORES[0.90]
-        elif confidence <= 0.95:
-            return Z_SCORES[0.90] + (confidence - 0.90) / 0.05 * (Z_SCORES[0.95] - Z_SCORES[0.90])
-        elif confidence <= 0.99:
-            return Z_SCORES[0.95] + (confidence - 0.95) / 0.04 * (Z_SCORES[0.99] - Z_SCORES[0.95])
+        elif c <= Decimal("0.95"):
+            return Z_SCORES[0.90] + (c - Decimal("0.90")) / Decimal("0.05") * (Z_SCORES[0.95] - Z_SCORES[0.90])
+        elif c <= Decimal("0.99"):
+            return Z_SCORES[0.95] + (c - Decimal("0.95")) / Decimal("0.04") * (Z_SCORES[0.99] - Z_SCORES[0.95])
         else:
             return Z_SCORES[0.99]
     

--- a/tests/test_float_contamination.py
+++ b/tests/test_float_contamination.py
@@ -8,7 +8,6 @@ Covers:
 - S-04: No float leaks in monetary output strings
 """
 
-import pytest
 from decimal import Decimal
 
 from qwed_finance import BondGuard, DerivativesGuard, OptionType
@@ -116,7 +115,7 @@ class TestDerivativesGuardMpmath:
             # Must be a string (Decimal-quantized), not a float
             assert isinstance(value, str), f"Greek {greek_name} is {type(value)}, expected str"
             # Must not have float artifacts
-            assert "e-" not in value.lower() or "e-0" not in value.lower(), \
+            assert "e-" not in value.lower(), \
                 f"Greek {greek_name} has scientific notation: {value}"
 
     def test_put_price_positive(self):
@@ -253,13 +252,13 @@ class TestRiskGuardDecimal:
 class TestNoFloatInOutput:
     """Ensure no float artifacts leak into any guard output strings."""
 
-    FLOAT_ARTIFACTS = [
+    FLOAT_ARTIFACTS = (
         "0.30000000000000004",   # 0.1 + 0.2
         "3.5999999999999943",    # sum of 360 × 0.01
         "e-",                    # scientific notation from float
         "nan",
         "inf",
-    ]
+    )
 
     def _check_no_float_leak(self, value: str):
         """Assert a string has no IEEE-754 artifacts."""

--- a/tests/test_float_contamination.py
+++ b/tests/test_float_contamination.py
@@ -1,0 +1,292 @@
+"""
+Tests for float contamination remediation (Issue #20).
+
+Covers:
+- C-01: BondGuard uses Decimal for YTM, Duration, Convexity
+- C-02: DerivativesGuard uses mpmath for Black-Scholes
+- C-03: RiskGuard uses Decimal for Beta, VaR, Sharpe
+- S-04: No float leaks in monetary output strings
+"""
+
+import pytest
+from decimal import Decimal
+
+from qwed_finance import BondGuard, DerivativesGuard, OptionType
+from qwed_finance.risk_guard import RiskGuard
+
+
+# ==================== BondGuard Decimal Tests ====================
+
+class TestBondGuardDecimal:
+    """Verify BondGuard uses Decimal internally — no IEEE-754 artifacts."""
+
+    def setup_method(self):
+        self.guard = BondGuard()
+
+    def test_ytm_solver_returns_decimal(self):
+        """_solve_ytm must return Decimal, not float."""
+        fv = Decimal("1000")
+        coupon = Decimal("25")  # 5% semi-annual
+        price = Decimal("950")
+        result = self.guard._solve_ytm(fv, coupon, price, 20, 2)
+        assert isinstance(result, Decimal), f"Expected Decimal, got {type(result)}"
+
+    def test_ytm_verification_no_float_in_output(self):
+        """Output strings must not contain float artifacts like 0.30000000000000004."""
+        result = self.guard.verify_ytm(1000, 0.05, 950, 10, "5.66%")
+        assert "000000000" not in result.computed_value
+        assert result.verified is True
+
+    def test_duration_uses_decimal(self):
+        """Duration accumulation must use Decimal — catches catastrophic cancellation."""
+        result = self.guard.verify_duration(
+            face_value=1000,
+            coupon_rate=0.05,
+            ytm=0.06,
+            years_to_maturity=10,
+            llm_duration="7.8950 years"
+        )
+        # Should verify within tolerance
+        assert result.verified is True
+        assert "000000000" not in result.computed_value
+
+    def test_convexity_uses_decimal(self):
+        """Convexity must use Decimal for weighted sum accumulation."""
+        result = self.guard.verify_convexity(
+            face_value=1000,
+            coupon_rate=0.05,
+            ytm=0.06,
+            years_to_maturity=10,
+            llm_convexity="72.00"
+        )
+        # Just check no float leak, not exact match
+        assert "000000000" not in result.computed_value
+
+    def test_accrued_interest_still_decimal(self):
+        """verify_accrued_interest was already Decimal — ensure no regression."""
+        result = self.guard.verify_accrued_interest(
+            face_value=1000,
+            coupon_rate=0.06,
+            days_since_last_coupon=45,
+            days_in_period=180,
+            llm_accrued="$7.50"
+        )
+        assert result.verified is True
+
+    def test_ytm_tolerance_is_decimal(self):
+        """BondGuard.tolerance_pct must be Decimal."""
+        assert isinstance(self.guard.tolerance_pct, Decimal)
+
+
+# ==================== DerivativesGuard mpmath Tests ====================
+
+class TestDerivativesGuardMpmath:
+    """Verify DerivativesGuard uses mpmath — no math.log/exp/sqrt."""
+
+    def setup_method(self):
+        self.guard = DerivativesGuard()
+
+    def test_black_scholes_call_price(self):
+        """Black-Scholes call price must match known reference value."""
+        result = self.guard.verify_black_scholes(
+            spot_price=100,
+            strike_price=100,
+            time_to_expiry=1.0,
+            risk_free_rate=0.05,
+            volatility=0.20,
+            option_type=OptionType.CALL,
+            llm_price="$10.45"
+        )
+        # Reference: ATM 1Y call with 20% vol ≈ $10.45
+        assert result.computed_price.startswith("$")
+        assert "000000000" not in result.computed_price
+
+    def test_greeks_are_decimal_strings(self):
+        """Greeks must be Decimal strings, not float round() output."""
+        result = self.guard.verify_black_scholes(
+            spot_price=100,
+            strike_price=105,
+            time_to_expiry=0.25,
+            risk_free_rate=0.05,
+            volatility=0.20,
+            option_type=OptionType.CALL,
+            llm_price="$2.48"
+        )
+        for greek_name, value in result.greeks.items():
+            # Must be a string (Decimal-quantized), not a float
+            assert isinstance(value, str), f"Greek {greek_name} is {type(value)}, expected str"
+            # Must not have float artifacts
+            assert "e-" not in value.lower() or "e-0" not in value.lower(), \
+                f"Greek {greek_name} has scientific notation: {value}"
+
+    def test_put_price_positive(self):
+        """OTM put price must be positive and properly formatted."""
+        result = self.guard.verify_black_scholes(
+            spot_price=100,
+            strike_price=95,
+            time_to_expiry=0.5,
+            risk_free_rate=0.05,
+            volatility=0.25,
+            option_type=OptionType.PUT,
+            llm_price="$3.00"
+        )
+        price_str = result.computed_price.replace("$", "")
+        price_val = Decimal(price_str)
+        assert price_val > 0
+
+    def test_put_call_parity_no_float_exp(self):
+        """Put-call parity must use mpmath.exp, not math.exp."""
+        result = self.guard.verify_put_call_parity(
+            call_price=10.45,
+            put_price=5.57,
+            spot_price=100,
+            strike_price=100,
+            time_to_expiry=1.0,
+            risk_free_rate=0.05
+        )
+        # Should verify parity within tolerance
+        assert "000000000" not in result.computed_price
+
+    def test_margin_call_uses_decimal(self):
+        """Margin call comparison must use Decimal for exact threshold check."""
+        result = self.guard.verify_margin_call(
+            account_equity=24999.99,
+            maintenance_margin=0.25,
+            position_value=100000,
+            llm_margin_call=True
+        )
+        # 24999.99 < 25000.00 → margin call
+        assert result.verified is True
+
+    def test_delta_uses_mpmath(self):
+        """Delta calculation must use mpmath norm_cdf."""
+        result = self.guard.verify_delta(
+            spot_price=100,
+            strike_price=100,
+            time_to_expiry=1.0,
+            risk_free_rate=0.05,
+            volatility=0.20,
+            option_type=OptionType.CALL,
+            llm_delta=0.6368
+        )
+        # ATM 1Y call delta ≈ 0.64
+        assert result.verified is True
+
+
+# ==================== RiskGuard Decimal Tests ====================
+
+class TestRiskGuardDecimal:
+    """Verify RiskGuard uses Decimal — prevents catastrophic cancellation."""
+
+    def setup_method(self):
+        self.guard = RiskGuard()
+
+    def test_var_uses_decimal_sqrt(self):
+        """VaR must use Decimal.sqrt() not math.sqrt()."""
+        result = self.guard.verify_var(
+            portfolio_value=1000000,
+            daily_volatility=0.02,
+            confidence_level=0.95,
+            holding_period_days=10,
+            llm_var="$104,012.29"
+        )
+        # VaR = 1M * 0.02 * 1.645 * sqrt(10) ≈ $104,012
+        assert result.computed_value.startswith("$")
+        assert "000000000" not in result.computed_value
+
+    def test_beta_decimal_accumulation(self):
+        """Beta must use Decimal to prevent catastrophic cancellation."""
+        # Use returns very close to their mean — triggers cancellation in float
+        asset = [0.01001, 0.01002, 0.01003, 0.00999, 0.00998]
+        market = [0.00501, 0.00502, 0.00503, 0.00499, 0.00498]
+        
+        result = self.guard.verify_beta(asset, market, "1.0000")
+        # The key test: does it return a valid Decimal result without NaN/Inf?
+        assert result.computed_value not in ("nan", "inf", "-inf", "ERROR")
+
+    def test_sharpe_uses_decimal(self):
+        """Sharpe ratio must use Decimal division."""
+        result = self.guard.verify_sharpe_ratio(
+            portfolio_return=0.12,
+            risk_free_rate=0.03,
+            portfolio_volatility=0.15,
+            llm_sharpe="0.6000"
+        )
+        assert result.verified is True
+        assert isinstance(self.guard.tolerance_pct, Decimal)
+
+    def test_sortino_uses_decimal_sqrt(self):
+        """Sortino must use Decimal.sqrt() for downside deviation."""
+        result = self.guard.verify_sortino_ratio(
+            portfolio_return=0.10,
+            target_return=0.02,
+            downside_returns=[-0.05, -0.03, -0.01],
+            llm_sortino="1.3000"
+        )
+        assert result.computed_value not in ("nan", "inf")
+
+    def test_max_drawdown_decimal(self):
+        """Max drawdown must use Decimal accumulation."""
+        values = [100, 95, 90, 88, 92, 85, 90, 95, 100]
+        result = self.guard.verify_max_drawdown(values, "15%")
+        assert result.verified is True
+
+    def test_information_ratio_decimal(self):
+        """IR must use Decimal division."""
+        result = self.guard.verify_information_ratio(
+            portfolio_return=0.12,
+            benchmark_return=0.10,
+            tracking_error=0.05,
+            llm_ir="0.4000"
+        )
+        assert result.verified is True
+
+    def test_z_scores_are_decimal(self):
+        """Z_SCORES dict values must be Decimal, not float."""
+        from qwed_finance.risk_guard import Z_SCORES
+        for conf, z in Z_SCORES.items():
+            assert isinstance(z, Decimal), f"Z_SCORES[{conf}] is {type(z)}, expected Decimal"
+
+
+# ==================== Cross-Guard Float Leak Detection ====================
+
+class TestNoFloatInOutput:
+    """Ensure no float artifacts leak into any guard output strings."""
+
+    FLOAT_ARTIFACTS = [
+        "0.30000000000000004",   # 0.1 + 0.2
+        "3.5999999999999943",    # sum of 360 × 0.01
+        "e-",                    # scientific notation from float
+        "nan",
+        "inf",
+    ]
+
+    def _check_no_float_leak(self, value: str):
+        """Assert a string has no IEEE-754 artifacts."""
+        for artifact in self.FLOAT_ARTIFACTS:
+            assert artifact not in value.lower(), \
+                f"Float artifact '{artifact}' found in: {value}"
+
+    def test_bond_ytm_output_clean(self):
+        guard = BondGuard()
+        r = guard.verify_ytm(1000, 0.05, 950, 10, "5.66%")
+        self._check_no_float_leak(r.computed_value)
+        if r.difference:
+            self._check_no_float_leak(r.difference)
+
+    def test_derivatives_bs_output_clean(self):
+        guard = DerivativesGuard()
+        r = guard.verify_black_scholes(100, 100, 1.0, 0.05, 0.20, OptionType.CALL, "$10.45")
+        self._check_no_float_leak(r.computed_price)
+
+    def test_risk_var_output_clean(self):
+        guard = RiskGuard()
+        r = guard.verify_var(1000000, 0.02, 0.95, 10, "$104012.29")
+        self._check_no_float_leak(r.computed_value)
+
+    def test_risk_beta_output_clean(self):
+        guard = RiskGuard()
+        asset = [0.05, 0.02, -0.01, 0.03, 0.04]
+        market = [0.04, 0.01, -0.02, 0.02, 0.03]
+        r = guard.verify_beta(asset, market, "1.0000")
+        self._check_no_float_leak(r.computed_value)

--- a/tests/test_rate_parsing.py
+++ b/tests/test_rate_parsing.py
@@ -8,6 +8,7 @@ Covers:
 """
 
 import pytest
+from decimal import Decimal, InvalidOperation
 
 from qwed_finance import BondGuard, FinanceVerifier
 
@@ -19,54 +20,59 @@ class TestBondGuardParseRate:
         self.guard = BondGuard()
 
     def test_explicit_percentage(self):
-        """'5.25%' must parse to 0.0525."""
-        assert self.guard._parse_rate("5.25%") == 0.0525
+        """'5.25%' must parse to Decimal('0.0525')."""
+        assert self.guard._parse_rate("5.25%") == Decimal("0.0525")
 
     def test_explicit_percentage_with_space(self):
-        """'5.25 %' must parse to 0.0525."""
-        assert self.guard._parse_rate("5.25 %") == 0.0525
+        """'5.25 %' must parse to Decimal('0.0525')."""
+        assert self.guard._parse_rate("5.25 %") == Decimal("0.0525")
 
     def test_decimal_fraction(self):
-        """'0.0525' must parse to 0.0525 (not reinterpreted)."""
-        assert self.guard._parse_rate("0.0525") == 0.0525
+        """'0.0525' must parse to Decimal('0.0525') (not reinterpreted)."""
+        assert self.guard._parse_rate("0.0525") == Decimal("0.0525")
 
     def test_value_above_one_not_divided(self):
-        """'1.5' must parse to 1.5 (150% for distressed debt), NOT 0.015.
+        """'1.5' must parse to Decimal('1.5') (150% for distressed debt), NOT 0.015.
 
         This is the core fix: the old heuristic (val < 1) would silently
         convert 1.5 to 0.015, which is 100x wrong for distressed debt.
         """
         result = self.guard._parse_rate("1.5")
-        assert result == 1.5, (
-            f"Expected 1.5 (150% as decimal), got {result}. "
+        assert result == Decimal("1.5"), (
+            f"Expected Decimal('1.5') (150% as decimal), got {result}. "
             "Old heuristic is still active!"
         )
 
     def test_boundary_value_one(self):
-        """'1.0' must parse to 1.0 (100%), not 0.01."""
+        """'1.0' must parse to Decimal('1.0') (100%), not 0.01."""
         result = self.guard._parse_rate("1.0")
-        assert result == 1.0
+        assert result == Decimal("1.0")
 
     def test_large_percentage_explicit(self):
-        """'150%' must parse to 1.5."""
-        assert self.guard._parse_rate("150%") == 1.5
+        """'150%' must parse to Decimal('1.5')."""
+        assert self.guard._parse_rate("150%") == Decimal("1.5")
 
     def test_zero_rate(self):
-        """'0' must parse to 0.0."""
-        assert self.guard._parse_rate("0") == 0.0
+        """'0' must parse to Decimal('0')."""
+        assert self.guard._parse_rate("0") == Decimal("0")
 
     def test_zero_percent(self):
-        """'0%' must parse to 0.0."""
-        assert self.guard._parse_rate("0%") == 0.0
+        """'0%' must parse to Decimal('0')."""
+        assert self.guard._parse_rate("0%") == Decimal("0")
 
     def test_whitespace_handling(self):
         """'  5.25%  ' must parse correctly with whitespace."""
-        assert self.guard._parse_rate("  5.25%  ") == 0.0525
+        assert self.guard._parse_rate("  5.25%  ") == Decimal("0.0525")
 
     def test_invalid_input_raises(self):
-        """Non-numeric input must raise ValueError (fail-closed)."""
-        with pytest.raises(ValueError):
+        """Non-numeric input must raise InvalidOperation (fail-closed)."""
+        with pytest.raises(InvalidOperation):
             self.guard._parse_rate("abc")
+
+    def test_returns_decimal_type(self):
+        """_parse_rate must return Decimal, not float."""
+        result = self.guard._parse_rate("5.25%")
+        assert isinstance(result, Decimal)
 
 
 class TestFinanceVerifierIRRParsing:
@@ -123,22 +129,22 @@ class TestCrossGuardConsistency:
         self.verifier = FinanceVerifier()
 
     def test_percentage_format_consistent(self):
-        """'5.25%' must produce 0.0525 in BondGuard."""
-        assert self.bond._parse_rate("5.25%") == 0.0525
+        """'5.25%' must produce Decimal('0.0525') in BondGuard."""
+        assert self.bond._parse_rate("5.25%") == Decimal("0.0525")
 
     def test_decimal_format_consistent(self):
-        """'0.0525' must produce 0.0525 in BondGuard."""
-        assert self.bond._parse_rate("0.0525") == 0.0525
+        """'0.0525' must produce Decimal('0.0525') in BondGuard."""
+        assert self.bond._parse_rate("0.0525") == Decimal("0.0525")
 
     def test_high_rate_consistent(self):
-        """'1.5' (150%) must produce 1.5 in BondGuard (no division)."""
-        assert self.bond._parse_rate("1.5") == 1.5
+        """'1.5' (150%) must produce Decimal('1.5') in BondGuard (no division)."""
+        assert self.bond._parse_rate("1.5") == Decimal("1.5")
 
     def test_irr_and_bond_agree_on_percentage(self):
         """Both guards must interpret '5.25%' the same way."""
         bond_rate = self.bond._parse_rate("5.25%")
         # Both should interpret 5.25% as 0.0525
-        assert bond_rate == 0.0525
+        assert bond_rate == Decimal("0.0525")
         # FinanceVerifier exercises the same parsing on "%" inputs
         result = self.verifier.verify_irr(
             cashflows=[-1000, 350, 350, 350],
@@ -154,5 +160,5 @@ class TestCrossGuardConsistency:
             cashflows=[-1000, 300, 400, 400, 300],
             llm_output="0.1490"
         )
-        assert bond_rate == 0.1490
+        assert bond_rate == Decimal("0.1490")
         assert result.verified is True  # parses same as decimal


### PR DESCRIPTION
## Summary

Closes #20 — Eliminates IEEE-754 float contamination from all three remaining financial guards by migrating to `Decimal` (exact arithmetic) and `mpmath` (arbitrary-precision transcendental functions).

**Before:** BondGuard, DerivativesGuard, and RiskGuard used native Python `float` for financial calculations, while TradingGuard and FinanceVerifier correctly used `Decimal`. This split caused inconsistent precision standards across the codebase.

**After:** All guards now use `Decimal` or `mpmath` — zero `float` in any financial math path.

## Changes

### BondGuard — `Decimal` (C-01)
| Method | Before | After |
|--------|--------|-------|
| `_solve_ytm()` | Newton-Raphson in `float` | Full `Decimal` arithmetic |
| `verify_ytm()` | `float` multiplication | `Decimal` at boundary |
| `verify_duration()` | `float` accumulation | `Decimal` accumulation |
| `verify_convexity()` | `float` accumulation | `Decimal` accumulation |
| `tolerance_pct` | `float` | `Decimal` |

### DerivativesGuard — `mpmath` (C-02)
| Method | Before | After |
|--------|--------|-------|
| `verify_black_scholes()` | `math.log/exp/sqrt/erf` | `mpmath.log/exp/sqrt/erf` (30 dp) |
| `_norm_cdf()` | `math.erf` | `mpmath.erf` |
| `_norm_pdf()` | `math.exp` | `mpmath.exp` |
| `_calculate_greeks()` | `round(float, N)` | `Decimal.quantize()` strings |
| `verify_put_call_parity()` | `math.exp` | `mpmath.exp` |
| `verify_margin_call()` | `float` comparison | `Decimal` comparison |

### RiskGuard — `Decimal` (C-03)
| Method | Before | After |
|--------|--------|-------|
| `verify_var()` | `math.sqrt()` float leak | `Decimal.sqrt()` |
| `verify_beta()` | `float` accumulation (catastrophic cancellation) | `Decimal` accumulation |
| `verify_sharpe_ratio()` | `float` division | `Decimal` division |
| `verify_sortino_ratio()` | `math.sqrt()` | `Decimal.sqrt()` |
| `verify_max_drawdown()` | `float` loop | `Decimal` loop |
| `verify_information_ratio()` | `float` division | `Decimal` division |
| `Z_SCORES` | `float` constants | `Decimal` constants |

### Tests — 23 new tests
- `TestBondGuardDecimal` — 6 tests (YTM solver type, output cleanliness, duration, convexity, accrued, tolerance type)
- `TestDerivativesGuardMpmath` — 6 tests (BS call, Greeks type, put price, put-call parity, margin, delta)
- `TestRiskGuardDecimal` — 7 tests (VaR sqrt, beta cancellation, Sharpe, Sortino, MaxDD, IR, Z_SCORES type)
- `TestNoFloatInOutput` — 4 tests (cross-guard IEEE-754 artifact detection)

## Breaking Changes

⚠️ **Greeks are now `str` (Decimal-quantized), not `float`**
```python
# Before
greeks["delta"]  # 0.4502 (float)

# After
greeks["delta"]  # "0.4502" (str — Decimal-quantized)
```
⚠️ mpmath is now a runtime dependency (already available as transitive dep via `sympy`)

148 passed in 2.90s


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Refactor**
  * Upgraded financial calculation engines across bond valuation, options pricing, and risk assessment modules to use high-precision arithmetic for improved accuracy and consistent, deterministic results.
  * Risk assessment confidence thresholds updated for consistent precision handling.

* **Tests**
  * Added comprehensive test suite to verify high-precision calculation behavior and ensure floating-point artifacts are eliminated from verification outputs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->